### PR TITLE
Add `ExternalService.stop/1`

### DIFF
--- a/lib/external_service.ex
+++ b/lib/external_service.ex
@@ -128,6 +128,16 @@ defmodule ExternalService do
   end
 
   @doc """
+  Stops the fuse for a specific service.
+  """
+  @spec stop(fuse_name()) :: :ok
+  def stop(fuse_name) when is_atom(fuse_name) do
+    :ok = Fuse.remove(fuse_name)
+    :ok = State.registered_name(fuse_name) |> Agent.stop()
+    :ok
+  end
+
+  @doc """
   Resets the given fuse.
 
   After reset, the fuse will be unbroken with no melts.

--- a/test/external_service_test.exs
+++ b/test/external_service_test.exs
@@ -36,6 +36,13 @@ defmodule ExternalServiceTest do
     end
   end
 
+  describe "stop" do
+    test "removes a fuse" do
+      ExternalService.stop(@fuse_name)
+      assert :fuse.ask(@fuse_name, :sync) == {:error, :not_found}
+    end
+  end
+
   describe "call" do
     @fuse_retries 5
 


### PR DESCRIPTION
Hi! Thanks for making ExternalService!

I have a use case in which I need to update the fuse configuration at runtime. Normally I would just call `:fuse.remove/1` and restart it with the new configuration, but `ExternalService` also creates an Agent on start to store the rate limiter configuration, and we need to shut down that one as well.

So this PR just adds a function that removes the fuse and shuts down the associated Agent.