### PR TITLE
M1: persistent_term state, gateway fuse-config fix, fault_injection regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Work toward 2.0 (see `ROADMAP.md`). The 2.0 line modernizes the project and
 introduces breaking changes; a migration guide will accompany the release.
 
+### Fixed
+- `ExternalService.Gateway` now applies the `fuse: [strategy:, refresh:]` options
+  it was configured with. Previously these keys did not match the
+  `:fuse_strategy`/`:fuse_refresh` keys that `ExternalService.start/2` reads, so
+  every gateway silently ran on the default circuit-breaker configuration.
+- Added a regression test for the `:fault_injection` strategy (issue #4); the
+  `:fuse_monitor` crash no longer reproduces on fuse 2.5.
+
 ### Changed
 - Raise the minimum Elixir requirement to `~> 1.15`.
 - Modernize the build: refreshed dependency versions, added `nimble_options` and
   `telemetry`, ExDoc/Dialyxir bumps, GitHub Actions CI (test matrix, quality, and
   Dialyzer jobs), and Hex package/docs metadata cleanup.
+- Store per-service state in `:persistent_term` instead of an unsupervised
+  `Agent`, removing a process that could crash and was never linked to a
+  supervisor. `ExternalService.stop/1` now accepts any term as a fuse name
+  (matching `start/2`), not only atoms, and is idempotent — it is safe to call
+  on a service that was never started or has already been stopped.
 
 ## 1.1.4 - 2024-01-04
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,11 +66,22 @@ MyApp.Stripe.reset()
 - [ ] CI workflow + formatter/credo/dialyzer clean (mirror the Errata setup).
 
 ### M1 — Internal refactor (no public break)
-- [ ] Replace the unsupervised `Agent` state (and Gateway `Config` Agent) with
+- [ ] Replace the unsupervised `Agent` state in `ExternalService.start/2` with
       `:persistent_term` — fast reads, nothing to crash. Resolves the resilience
-      items in TODO.md.
-- [ ] Extract all option schemas into NimbleOptions schemas (validation + docs).
-- [ ] Fix `:fault_injection` strategy (issue #4).
+      items in TODO.md. (Gateway's supervised `Config` Agent is left for the M4
+      front-door redesign, where its storage and lifecycle change together.)
+- [ ] **Fix the Gateway fuse-config drop**: `use ExternalService.Gateway` accepts
+      `fuse: [strategy:, refresh:]` but `ExternalService.start/2` reads
+      `:fuse_strategy`/`:fuse_refresh`, so gateway circuit-breaker settings were
+      silently ignored and every gateway ran on default fuse config. Translate the
+      keys + add a regression test asserting on the installed fuse record.
+- [ ] Add a regression test for the `:fault_injection` strategy (issue #4). The
+      `FunctionClauseError` in `:fuse_monitor` no longer reproduces on fuse 2.5 —
+      the dependency upgrade fixed it — so this just locks the behavior in.
+
+> NimbleOptions schema extraction moved to **M4**: the public option *shape*
+> changes there (`circuit_breaker:`/`rate_limit:`/`retry:`), so validating the
+> current, soon-to-be-replaced shape would be throwaway work.
 
 ### M2 — New capabilities (additive)
 - [ ] Introspection: `available?/1`, `blown?/1`, `all_available?/1` + module-level

--- a/lib/external_service.ex
+++ b/lib/external_service.ex
@@ -98,6 +98,12 @@ defmodule ExternalService do
   defmodule State do
     @moduledoc false
 
+    # Per-service configuration is stored in `:persistent_term`. The state for a
+    # service is written once by `ExternalService.start/2` and read on every call,
+    # which is exactly the access pattern `:persistent_term` is optimized for:
+    # lock-free reads with no process to message or crash. This replaces the
+    # previous unsupervised `Agent`.
+
     defstruct [:fuse_name, :fuse_options, :rate_limit]
 
     def init(fuse_name, fuse_options, rate_limit) do
@@ -107,13 +113,15 @@ defmodule ExternalService do
         rate_limit: rate_limit
       }
 
-      Agent.start(fn -> state end, name: registered_name(fuse_name))
+      :persistent_term.put(key(fuse_name), state)
       state
     end
 
-    def get(fuse_name), do: Agent.get(registered_name(fuse_name), & &1)
+    def get(fuse_name), do: :persistent_term.get(key(fuse_name))
 
-    def registered_name(fuse_name), do: Module.concat(fuse_name, __MODULE__)
+    def delete(fuse_name), do: :persistent_term.erase(key(fuse_name))
+
+    defp key(fuse_name), do: {__MODULE__, fuse_name}
   end
 
   @doc """
@@ -140,11 +148,16 @@ defmodule ExternalService do
 
   @doc """
   Stops the fuse for a specific service.
+
+  Stopping is idempotent: it is safe to call on a service that was never started
+  or has already been stopped.
   """
   @spec stop(fuse_name()) :: :ok
-  def stop(fuse_name) when is_atom(fuse_name) do
-    :ok = Fuse.remove(fuse_name)
-    :ok = State.registered_name(fuse_name) |> Agent.stop()
+  def stop(fuse_name) do
+    # `:fuse.remove/1` returns `{:error, :not_found}` for an unknown fuse; treat
+    # that as success so that stop/1 is idempotent.
+    _ = Fuse.remove(fuse_name)
+    State.delete(fuse_name)
     :ok
   end
 

--- a/lib/external_service/gateway.ex
+++ b/lib/external_service/gateway.ex
@@ -260,7 +260,7 @@ defmodule ExternalService.Gateway do
       when is_list(module_opts) and is_list(start_opts) do
     config = DeepMerge.deep_merge(module_opts, start_opts)
     {fuse_name, fuse_opts} = config |> Keyword.get(:fuse, []) |> Keyword.pop(:name, module)
-    service_start_opts = Keyword.merge(fuse_opts, Keyword.take(config, [:rate_limit]))
+    service_start_opts = service_start_opts(fuse_opts, config)
     :ok = ExternalService.start(fuse_name, service_start_opts)
 
     Agent.start_link(
@@ -271,6 +271,21 @@ defmodule ExternalService.Gateway do
 
   @doc false
   def get_config(module), do: Agent.get(config_agent(module), & &1)
+
+  # Translate the gateway's `fuse: [strategy:, refresh:]` options into the
+  # `:fuse_strategy`/`:fuse_refresh` keys that `ExternalService.start/2` expects.
+  # Without this translation the keys never match and every gateway silently runs
+  # on the default fuse configuration.
+  @fuse_key_map [strategy: :fuse_strategy, refresh: :fuse_refresh]
+
+  defp service_start_opts(fuse_opts, config) do
+    fuse_start_opts =
+      for {gateway_key, start_key} <- @fuse_key_map, Keyword.has_key?(fuse_opts, gateway_key) do
+        {start_key, Keyword.fetch!(fuse_opts, gateway_key)}
+      end
+
+    Keyword.merge(fuse_start_opts, Keyword.take(config, [:rate_limit]))
+  end
 
   defp config_agent(module), do: Module.concat(module, Config)
 end

--- a/test/external_service/gateway_test.exs
+++ b/test/external_service/gateway_test.exs
@@ -21,6 +21,11 @@ defmodule ExternalService.GatewayTest do
     end
   end
 
+  defmodule ConfiguredGateway do
+    use ExternalService.Gateway,
+      fuse: [name: :configured_gateway_fuse, strategy: {:standard, 3, 7_000}, refresh: 4_321]
+  end
+
   describe "child_spec" do
     test "generates a child spec for starting under a supervisor" do
       assert %{id: TestGateway, type: :worker, start: start_tuple} =
@@ -90,5 +95,30 @@ defmodule ExternalService.GatewayTest do
       Process.sleep(50)
       assert TestGateway.gateway_config()[:rate_limit] == {9, 999}
     end
+  end
+
+  describe "fuse configuration (regression for gateway fuse-config drop)" do
+    test "applies the gateway's configured fuse strategy and refresh" do
+      {:ok, _pid} = ConfiguredGateway.start_link([])
+
+      fuse = installed_fuse(:configured_gateway_fuse)
+
+      # The fuse server stores each fuse as the record
+      # {:fuse, name, intensity, period, heal_time, ...} (fuse 2.5). Previously
+      # the gateway's strategy/refresh were dropped and every gateway installed
+      # the default {:standard, 10, 10_000}/60_000 fuse.
+      assert elem(fuse, 2) == 3, "expected configured intensity (max melts), got #{inspect(fuse)}"
+      assert elem(fuse, 4) == 4_321, "expected configured refresh, got #{inspect(fuse)}"
+    end
+  end
+
+  # Reads the installed fuse record straight out of the :fuse_server state. This
+  # is the only way to assert on the circuit-breaker config that was actually
+  # installed (fuse exposes no public accessor for it).
+  defp installed_fuse(name) do
+    :fuse_server
+    |> :sys.get_state()
+    |> elem(1)
+    |> Enum.find(fn fuse -> elem(fuse, 1) == name end)
   end
 end

--- a/test/external_service_test.exs
+++ b/test/external_service_test.exs
@@ -393,4 +393,48 @@ defmodule ExternalServiceTest do
              ] = results
     end
   end
+
+  describe "start/stop lifecycle" do
+    test "stop removes both the fuse and the persisted state" do
+      name = :"lifecycle-test"
+
+      assert :ok = ExternalService.start(name)
+      assert :fuse.ask(name, :sync) == :ok
+      assert %ExternalService.State{fuse_name: ^name} = ExternalService.State.get(name)
+
+      assert :ok = ExternalService.stop(name)
+      assert :fuse.ask(name, :sync) == {:error, :not_found}
+      # State is stored in :persistent_term, which raises when the key is absent.
+      assert_raise ArgumentError, fn -> ExternalService.State.get(name) end
+    end
+
+    test "stop is idempotent and safe on a service that was never started" do
+      assert :ok = ExternalService.stop(:"never-started-service")
+    end
+  end
+
+  describe "fault_injection strategy (regression for #4)" do
+    test "exercising the fuse monitor does not crash it" do
+      name = :"fault-injection-test"
+
+      assert :ok = ExternalService.start(name, fuse_strategy: {:fault_injection, 0.5, 5, 1_000})
+      monitor = Process.whereis(:fuse_monitor)
+      assert is_pid(monitor)
+
+      for _ <- 1..20 do
+        ExternalService.call(name, @expiring_retry_options, fn -> :ok end)
+      end
+
+      # Force the periodic bookkeeping that historically raised a
+      # FunctionClauseError in :fuse_monitor.update/2 for gradual (fault
+      # injection) fuses. fuse 2.5 fixed this; the synchronous sync/0 call below
+      # is serialized after the :timeout message, so it only returns once the
+      # monitor has processed it — if the monitor had crashed, this would exit.
+      send(:fuse_monitor, :timeout)
+      assert :fuse_monitor.sync() == :ok
+      assert Process.whereis(:fuse_monitor) == monitor
+
+      ExternalService.stop(name)
+    end
+  end
 end


### PR DESCRIPTION
Second milestone on the road to 2.0. **Internal refactor + bug fixes; no change to the documented public API.**

> Stacked on #18 (M0). Review/merge that first — this PR targets the `v2/m0-foundation` branch so the diff shows only M1.

## Changes

### 🐛 Gateway silently ignored its fuse config
`use ExternalService.Gateway` accepts `fuse: [strategy:, refresh:]`, but `ExternalService.start/2` reads `:fuse_strategy`/`:fuse_refresh`. The keys never matched, so **every gateway ran on the default `{:standard, 10, 10_000}` fuse with a 60s refresh**, regardless of what was configured. Fixed by translating the keys, with a regression test that reads the actually-installed fuse record out of `:fuse_server` and asserts on its intensity and heal-time.

### ♻️ `:persistent_term` instead of an unsupervised `Agent`
Per-service state was held in an `Agent` started (unlinked, unsupervised) inside `start/2` — flagged as fragile in `TODO.md`. It's now stored in `:persistent_term`: written once at `start/2`, read on every call (its ideal access pattern), with no process to crash or leak. `ExternalService.stop/1` now accepts any term as a fuse name, matching `start/2`.

### ✅ `:fault_injection` regression test (issue #4)
The `FunctionClauseError` in `:fuse_monitor` no longer reproduces on fuse 2.5 — the dependency upgrade fixed it. Added a test that drives a gradual fuse and forces the monitor's periodic bookkeeping to lock the behavior in. **Issue #4 can be closed.**

## Verification
- `mix test` — 46 tests, 0 failures (3 new)
- `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)