### PR TITLE
M2: introspection, telemetry, and count-based retries + jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ introduces breaking changes; a migration guide will accompany the release.
   `ExternalService.available?/1`, `ExternalService.blown?/1`, and
   `ExternalService.all_available?/1`, plus `available?/0` and `blown?/0` on
   modules using `ExternalService.Gateway`.
+- `:telemetry` events for guarded calls: `[:external_service, :call, :start | :stop | :exception]`
+  (a span around each call), `[:external_service, :call, :retry]`,
+  `[:external_service, :circuit_breaker, :blown]`, and
+  `[:external_service, :rate_limit, :sleep]`. See the `ExternalService` module
+  docs for measurements and metadata.
 
 ### Fixed
 - `ExternalService.Gateway` now applies the `fuse: [strategy:, refresh:]` options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ introduces breaking changes; a migration guide will accompany the release.
   `[:external_service, :circuit_breaker, :blown]`, and
   `[:external_service, :rate_limit, :sleep]`. See the `ExternalService` module
   docs for measurements and metadata.
+- `RetryOptions.max_attempts` to bound the total number of attempts (initial plus
+  retries), complementing the existing time-based `:expiry`.
+- `RetryOptions.randomize` now also accepts a float jitter proportion (e.g.
+  `0.25` for +/- 25%) in addition to `true`/`false`.
 
 ### Fixed
 - `ExternalService.Gateway` now applies the `fuse: [strategy:, refresh:]` options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Work toward 2.0 (see `ROADMAP.md`). The 2.0 line modernizes the project and
 introduces breaking changes; a migration guide will accompany the release.
 
+### Added
+- Introspection for circuit breaker state ([issue #5](https://github.com/jvoegele/external_service/issues/5)):
+  `ExternalService.available?/1`, `ExternalService.blown?/1`, and
+  `ExternalService.all_available?/1`, plus `available?/0` and `blown?/0` on
+  modules using `ExternalService.Gateway`.
+
 ### Fixed
 - `ExternalService.Gateway` now applies the `fuse: [strategy:, refresh:]` options
   it was configured with. Previously these keys did not match the

--- a/lib/external_service.ex
+++ b/lib/external_service.ex
@@ -1,6 +1,49 @@
 defmodule ExternalService do
   @moduledoc """
   ExternalService handles all retry and circuit breaker logic for calls to external services.
+
+  ## Telemetry
+
+  `ExternalService` emits [`:telemetry`](https://hexdocs.pm/telemetry) events so
+  that calls to external services can be observed and instrumented. Attach a
+  handler to any of the events below to forward them to your metrics or logging
+  backend.
+
+  All events carry a `:service` key in their metadata, which is the fuse name of
+  the service the event relates to.
+
+    * `[:external_service, :call, :start]` - emitted when a guarded call begins.
+      * Measurements: `:system_time`, `:monotonic_time`
+      * Metadata: `:service`
+
+    * `[:external_service, :call, :stop]` - emitted when a guarded call completes
+      (including when it returns an error tuple such as `retries_exhausted` or
+      `fuse_blown`).
+      * Measurements: `:duration`, `:monotonic_time`
+      * Metadata: `:service`, `:result` (the value returned from the call)
+
+    * `[:external_service, :call, :exception]` - emitted when a guarded call
+      raises (for example a non-retriable exception, or `call!/3` raising on a
+      blown fuse or exhausted retries).
+      * Measurements: `:duration`, `:monotonic_time`
+      * Metadata: `:service`, `:kind`, `:reason`, `:stacktrace`
+
+    * `[:external_service, :call, :retry]` - emitted each time a call's function
+      fails in a way that melts the circuit breaker (it returned `:retry` /
+      `{:retry, reason}` or raised). Whether another attempt is actually made
+      depends on the retry options.
+      * Measurements: `:count` (always `1`)
+      * Metadata: `:service`, `:reason`
+
+    * `[:external_service, :circuit_breaker, :blown]` - emitted when a call is
+      rejected because the service's circuit breaker is blown.
+      * Measurements: `:count` (always `1`)
+      * Metadata: `:service`
+
+    * `[:external_service, :rate_limit, :sleep]` - emitted when a call is
+      throttled and put to sleep to stay within the configured rate limit.
+      * Measurements: `:sleep_time` (milliseconds)
+      * Metadata: `:service`
   """
 
   alias ExternalService.RateLimit
@@ -232,12 +275,14 @@ defmodule ExternalService do
   @spec call(fuse_name(), RetryOptions.t(), retriable_function()) ::
           error | (function_result :: any)
   def call(fuse_name, retry_opts \\ %RetryOptions{}, function) do
-    case call_with_retry(fuse_name, retry_opts, function) do
-      {:no_retry, result} -> result
-      {:error, :retry} -> {:error, {:retries_exhausted, :reason_unknown}}
-      {:error, {:retry, reason}} -> {:error, {:retries_exhausted, reason}}
-      result -> result
-    end
+    call_span(fuse_name, fn ->
+      case call_with_retry(fuse_name, retry_opts, function) do
+        {:no_retry, result} -> result
+        {:error, :retry} -> {:error, {:retries_exhausted, :reason_unknown}}
+        {:error, {:retry, reason}} -> {:error, {:retries_exhausted, reason}}
+        result -> result
+      end
+    end)
   end
 
   @doc """
@@ -246,23 +291,25 @@ defmodule ExternalService do
   @spec call!(fuse_name(), RetryOptions.t(), retriable_function()) ::
           function_result :: any | no_return
   def call!(fuse_name, retry_opts \\ %RetryOptions{}, function) do
-    case call_with_retry(fuse_name, retry_opts, function) do
-      {:no_retry, result} ->
-        result
+    call_span(fuse_name, fn ->
+      case call_with_retry(fuse_name, retry_opts, function) do
+        {:no_retry, result} ->
+          result
 
-      {:error, :retry} ->
-        raise ExternalService.RetriesExhaustedError, message: "fuse_name: #{fuse_name}"
+        {:error, :retry} ->
+          raise ExternalService.RetriesExhaustedError, message: "fuse_name: #{fuse_name}"
 
-      {:error, {:retry, reason}} ->
-        raise ExternalService.RetriesExhaustedError,
-          message: "reason: #{inspect(reason)}, fuse_name: #{fuse_name}"
+        {:error, {:retry, reason}} ->
+          raise ExternalService.RetriesExhaustedError,
+            message: "reason: #{inspect(reason)}, fuse_name: #{fuse_name}"
 
-      {:error, {:fuse_blown, fuse_name}} ->
-        raise ExternalService.FuseBlownError, message: inspect(fuse_name)
+        {:error, {:fuse_blown, fuse_name}} ->
+          raise ExternalService.FuseBlownError, message: inspect(fuse_name)
 
-      {:error, {:fuse_not_found, fuse_name}} ->
-        raise ExternalService.FuseNotFoundError, message: fuse_not_found_message(fuse_name)
-    end
+        {:error, {:fuse_not_found, fuse_name}} ->
+          raise ExternalService.FuseNotFoundError, message: fuse_not_found_message(fuse_name)
+      end
+    end)
   end
 
   @doc """
@@ -347,9 +394,15 @@ defmodule ExternalService do
 
     Retry.retry with: apply_retry_options(retry_opts), rescue_only: retry_opts.rescue_only do
       case Fuse.ask(fuse_name, :sync) do
-        :ok -> try_function(fuse_name, function)
-        :blown -> throw(:blown)
-        {:error, :not_found} -> throw(:not_found)
+        :ok ->
+          try_function(fuse_name, function)
+
+        :blown ->
+          emit_blown(fuse_name)
+          throw(:blown)
+
+        {:error, :not_found} ->
+          throw(:not_found)
       end
     after
       {:no_retry, _} = result -> result
@@ -394,10 +447,12 @@ defmodule ExternalService do
 
     case RateLimit.call(rate_limit, function) do
       {:retry, reason} ->
+        emit_retry(fuse_name, reason)
         Fuse.melt(fuse_name)
         {:error, {:retry, reason}}
 
       :retry ->
+        emit_retry(fuse_name, :reason_unknown)
         Fuse.melt(fuse_name)
         {:error, :retry}
 
@@ -406,8 +461,32 @@ defmodule ExternalService do
     end
   rescue
     error ->
+      emit_retry(fuse_name, error)
       Fuse.melt(fuse_name)
       reraise error, __STACKTRACE__
+  end
+
+  defp call_span(fuse_name, fun) do
+    :telemetry.span([:external_service, :call], %{service: fuse_name}, fn ->
+      result = fun.()
+      {result, %{service: fuse_name, result: result}}
+    end)
+  end
+
+  defp emit_retry(fuse_name, reason) do
+    :telemetry.execute(
+      [:external_service, :call, :retry],
+      %{count: 1},
+      %{service: fuse_name, reason: reason}
+    )
+  end
+
+  defp emit_blown(fuse_name) do
+    :telemetry.execute(
+      [:external_service, :circuit_breaker, :blown],
+      %{count: 1},
+      %{service: fuse_name}
+    )
   end
 
   defp log_fuse_not_found(fuse_name) do

--- a/lib/external_service.ex
+++ b/lib/external_service.ex
@@ -429,16 +429,32 @@ defmodule ExternalService do
         {:linear, initial_delay, factor} -> linear_backoff(initial_delay, factor)
       end
 
-    retry_opts
-    |> Map.take([:randomize, :expiry, :cap])
-    |> Enum.reduce(delay_stream, fn {key, value}, acc ->
-      if value do
-        apply(Retry.DelayStreams, key, [acc, value])
-      else
-        acc
-      end
-    end)
+    delay_stream
+    |> apply_randomize(retry_opts.randomize)
+    |> apply_if(retry_opts.cap, &cap/2)
+    |> apply_if(retry_opts.expiry, &expiry/2)
+    |> apply_max_attempts(retry_opts.max_attempts)
   end
+
+  # `randomize` accepts a boolean or an explicit jitter proportion. Note that
+  # `Retry.DelayStreams.randomize/2` expects a number, so a bare `true` must use
+  # the arity-1 default rather than being passed through.
+  defp apply_randomize(stream, proportion) when is_number(proportion),
+    do: Retry.DelayStreams.randomize(stream, proportion)
+
+  defp apply_randomize(stream, true), do: Retry.DelayStreams.randomize(stream)
+  defp apply_randomize(stream, _falsy), do: stream
+
+  defp apply_if(stream, nil, _fun), do: stream
+  defp apply_if(stream, value, fun), do: fun.(stream, value)
+
+  # `max_attempts` counts the initial attempt plus retries, so the delay stream
+  # (one delay per retry) is limited to `max_attempts - 1` elements.
+  defp apply_max_attempts(stream, nil), do: stream
+
+  defp apply_max_attempts(stream, max_attempts)
+       when is_integer(max_attempts) and max_attempts > 0,
+       do: Stream.take(stream, max_attempts - 1)
 
   @spec try_function(fuse_name, retriable_function) ::
           {:error, {:retry, any}} | {:error, :retry} | {:no_retry, any} | no_return

--- a/lib/external_service.ex
+++ b/lib/external_service.ex
@@ -170,6 +170,55 @@ defmodule ExternalService do
   def reset_fuse(fuse_name), do: Fuse.reset(fuse_name)
 
   @doc """
+  Returns `true` if the service is currently available, meaning its circuit
+  breaker is not blown.
+
+  This is useful for the circuit breaker pattern: before kicking off expensive
+  work, you can check whether the services it depends on are available and bail
+  out early (returning a degraded response) if any of them are not.
+
+  A service that has not been started (see `start/2`) is reported as not
+  available. Note that availability can change between this check and a
+  subsequent `call/3`, so this is a best-effort signal, not a guarantee.
+
+  ## Examples
+
+      if ExternalService.available?(:payments) do
+        charge(order)
+      else
+        {:error, :payments_unavailable}
+      end
+  """
+  @spec available?(fuse_name()) :: boolean()
+  def available?(fuse_name), do: Fuse.ask(fuse_name, :sync) == :ok
+
+  @doc """
+  Returns `true` if the service's circuit breaker is currently blown.
+
+  A service that has not been started (see `start/2`) is _not_ considered blown;
+  use `available?/1` if you want "ready to use" semantics that also account for
+  services that were never started.
+  """
+  @spec blown?(fuse_name()) :: boolean()
+  def blown?(fuse_name), do: Fuse.ask(fuse_name, :sync) == :blown
+
+  @doc """
+  Returns `true` only if every service in `fuse_names` is `available?/1`.
+
+  Useful for guarding work that depends on several services at once.
+
+  ## Examples
+
+      if ExternalService.all_available?([:payments, :inventory]) do
+        place_order(order)
+      else
+        {:error, :service_unavailable}
+      end
+  """
+  @spec all_available?([fuse_name()]) :: boolean()
+  def all_available?(fuse_names), do: Enum.all?(fuse_names, &available?/1)
+
+  @doc """
   Given a fuse name and retry options execute a function handling any retry and circuit breaker
   logic.
 

--- a/lib/external_service/gateway.ex
+++ b/lib/external_service/gateway.ex
@@ -157,6 +157,20 @@ defmodule ExternalService.Gateway do
             ) ::
               Enumerable.t()
 
+  @doc """
+  Returns `true` if the gateway's service is currently available.
+
+  See `ExternalService.available?/1` for more information.
+  """
+  @callback available?() :: boolean()
+
+  @doc """
+  Returns `true` if the gateway's circuit breaker is currently blown.
+
+  See `ExternalService.blown?/1` for more information.
+  """
+  @callback blown?() :: boolean()
+
   defmacro __using__(opts) do
     quote do
       @behaviour ExternalService.Gateway
@@ -188,6 +202,12 @@ defmodule ExternalService.Gateway do
         config = get_config()
         ExternalService.reset_fuse(fuse_name(config))
       end
+
+      @impl ExternalService.Gateway
+      def available?, do: ExternalService.available?(fuse_name(get_config()))
+
+      @impl ExternalService.Gateway
+      def blown?, do: ExternalService.blown?(fuse_name(get_config()))
 
       @doc """
       Returns the configuration with which the gateway was started.

--- a/lib/external_service/rate_limit.ex
+++ b/lib/external_service/rate_limit.ex
@@ -66,6 +66,13 @@ defmodule ExternalService.RateLimit do
 
       {:error, _} ->
         sleep_time = sleep_time(rate_limit)
+
+        :telemetry.execute(
+          [:external_service, :rate_limit, :sleep],
+          %{sleep_time: sleep_time},
+          %{service: rate_limit.fuse}
+        )
+
         log_sleep(rate_limit.fuse, bucket, limit, window, sleep_time, sleep_count)
         rate_limit.sleep.(sleep_time)
         call(rate_limit, function, sleep_count + 1)

--- a/lib/external_service/retry_options.ex
+++ b/lib/external_service/retry_options.ex
@@ -19,20 +19,37 @@ defmodule ExternalService.RetryOptions do
           | {:linear, initial_delay :: pos_integer(), factor :: pos_integer()}
 
   @typedoc """
+  Controls how much random jitter is applied to the delay between retries.
+
+    * `false` (the default) applies no jitter.
+    * `true` applies the default jitter of +/- 10%.
+    * a number between `0.0` and `1.0` applies that proportion of jitter
+      (for example `0.25` for +/- 25%).
+
+  Jitter helps avoid the "thundering herd" problem, where many clients that
+  failed at the same time would otherwise retry in lockstep.
+  """
+  @type randomize :: boolean() | float()
+
+  @typedoc """
   Struct representing the retry options to apply to calls to external services.
 
     * `backoff`: tuple describing the backoff strategy (see `t:backoff/0`)
-    * `randomize`: boolean indicating whether or not delays between retries should be randomized
-    * `expiry`: limit total length of time to allow for retries to the specified time budget
-    *   milliseconds
+    * `randomize`: how much random jitter to apply to delays (see `t:randomize/0`)
+    * `expiry`: limit the total length of time to allow for retries to the
+        specified time budget, in milliseconds
+    * `max_attempts`: limit the total number of attempts (the initial attempt
+        plus any retries) to the specified number; defaults to `nil` (no limit,
+        bounded only by `expiry` and/or the circuit breaker)
     * `cap`: limit maximum amount of time between retries to the specified number of milliseconds
     * `rescue_only`: retry only on exceptions matching one of the list of provided exception types,
         (defaults to `[RuntimeError]`)
   """
   @type t :: %__MODULE__{
           backoff: backoff(),
-          randomize: boolean(),
+          randomize: randomize(),
           expiry: pos_integer() | nil,
+          max_attempts: pos_integer() | nil,
           cap: pos_integer() | nil,
           rescue_only: list(module())
         }
@@ -40,6 +57,7 @@ defmodule ExternalService.RetryOptions do
   defstruct backoff: {:exponential, 10},
             randomize: false,
             expiry: nil,
+            max_attempts: nil,
             cap: nil,
             rescue_only: [RuntimeError]
 

--- a/test/external_service/gateway_test.exs
+++ b/test/external_service/gateway_test.exs
@@ -26,6 +26,12 @@ defmodule ExternalService.GatewayTest do
       fuse: [name: :configured_gateway_fuse, strategy: {:standard, 3, 7_000}, refresh: 4_321]
   end
 
+  defmodule IntrospectionGateway do
+    use ExternalService.Gateway,
+      fuse: [name: :introspection_gateway_fuse, strategy: {:standard, 1, 10_000}],
+      retry: [backoff: {:linear, 0, 1}]
+  end
+
   describe "child_spec" do
     test "generates a child spec for starting under a supervisor" do
       assert %{id: TestGateway, type: :worker, start: start_tuple} =
@@ -109,6 +115,21 @@ defmodule ExternalService.GatewayTest do
       # the default {:standard, 10, 10_000}/60_000 fuse.
       assert elem(fuse, 2) == 3, "expected configured intensity (max melts), got #{inspect(fuse)}"
       assert elem(fuse, 4) == 4_321, "expected configured refresh, got #{inspect(fuse)}"
+    end
+  end
+
+  describe "introspection" do
+    test "available?/blown? reflect the gateway's circuit breaker state" do
+      {:ok, _pid} = IntrospectionGateway.start_link([])
+
+      assert IntrospectionGateway.available?()
+      refute IntrospectionGateway.blown?()
+
+      # Drive the fuse past its tolerance of 1 melt so the breaker trips.
+      IntrospectionGateway.external_call(fn -> :retry end)
+
+      assert IntrospectionGateway.blown?()
+      refute IntrospectionGateway.available?()
     end
   end
 

--- a/test/external_service_test.exs
+++ b/test/external_service_test.exs
@@ -437,4 +437,46 @@ defmodule ExternalServiceTest do
       ExternalService.stop(name)
     end
   end
+
+  describe "introspection" do
+    setup do
+      name = :"introspection-test"
+      ExternalService.start(name, fuse_strategy: {:standard, 1, 10_000})
+      on_exit(fn -> ExternalService.stop(name) end)
+      [name: name]
+    end
+
+    test "available?/blown? for a freshly started service", %{name: name} do
+      assert ExternalService.available?(name)
+      refute ExternalService.blown?(name)
+    end
+
+    test "available?/blown? once the breaker is blown", %{name: name} do
+      blow_fuse(name)
+
+      assert ExternalService.blown?(name)
+      refute ExternalService.available?(name)
+    end
+
+    test "a service that was never started is neither available nor blown" do
+      refute ExternalService.available?(:"never-started-service")
+      refute ExternalService.blown?(:"never-started-service")
+    end
+
+    test "all_available? requires every service to be available", %{name: name} do
+      other = :"introspection-test-2"
+      ExternalService.start(other, fuse_strategy: {:standard, 1, 10_000})
+      on_exit(fn -> ExternalService.stop(other) end)
+
+      assert ExternalService.all_available?([name, other])
+
+      blow_fuse(other)
+      refute ExternalService.all_available?([name, other])
+    end
+  end
+
+  # Trips a service's circuit breaker by melting it past its configured tolerance.
+  defp blow_fuse(name) do
+    ExternalService.call(name, %RetryOptions{backoff: {:linear, 0, 1}}, fn -> :retry end)
+  end
 end

--- a/test/external_service_test.exs
+++ b/test/external_service_test.exs
@@ -475,8 +475,104 @@ defmodule ExternalServiceTest do
     end
   end
 
+  describe "telemetry" do
+    @telemetry_events [
+      [:external_service, :call, :start],
+      [:external_service, :call, :stop],
+      [:external_service, :call, :exception],
+      [:external_service, :call, :retry],
+      [:external_service, :circuit_breaker, :blown],
+      [:external_service, :rate_limit, :sleep]
+    ]
+
+    setup do
+      test_pid = self()
+      handler_id = "telemetry-test-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach_many(
+        handler_id,
+        @telemetry_events,
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
+    test "emits call start and stop for a successful call" do
+      name = start_fuse(:"telemetry-success")
+      assert ExternalService.call(name, fn -> {:ok, 42} end) == {:ok, 42}
+
+      assert_received {:telemetry, [:external_service, :call, :start], measurements,
+                       %{service: ^name}}
+
+      assert is_integer(measurements.system_time)
+
+      assert_received {:telemetry, [:external_service, :call, :stop], %{duration: duration},
+                       %{service: ^name, result: {:ok, 42}}}
+
+      assert is_integer(duration)
+    end
+
+    test "emits a retry event when the function asks to retry" do
+      name = start_fuse(:"telemetry-retry")
+      ExternalService.call(name, @expiring_retry_options, fn -> {:retry, :boom} end)
+
+      assert_received {:telemetry, [:external_service, :call, :retry], %{count: 1},
+                       %{service: ^name, reason: :boom}}
+    end
+
+    test "emits a call exception event when the function raises a non-retriable error" do
+      name = start_fuse(:"telemetry-exception")
+      retry_opts = %RetryOptions{backoff: {:linear, 0, 1}, rescue_only: [ArgumentError]}
+
+      assert_raise RuntimeError, fn ->
+        ExternalService.call(name, retry_opts, fn -> raise "boom" end)
+      end
+
+      assert_received {:telemetry, [:external_service, :call, :exception], %{duration: _},
+                       %{service: ^name, kind: :error, reason: %RuntimeError{}}}
+    end
+
+    test "emits a circuit_breaker blown event when the breaker is open" do
+      name = start_fuse(:"telemetry-blown", fuse_strategy: {:standard, 1, 10_000})
+      blow_fuse(name)
+      ExternalService.call(name, fn -> :ok end)
+
+      assert_received {:telemetry, [:external_service, :circuit_breaker, :blown], %{count: 1},
+                       %{service: ^name}}
+    end
+
+    test "emits a rate_limit sleep event when throttled" do
+      name = :"telemetry-rate-limit"
+      bucket = ExternalService.RateLimit.bucket_name(name)
+      sleep = fn _time -> ExRated.delete_bucket(bucket) end
+      ExternalService.start(name, rate_limit: {1, :timer.minutes(1)}, sleep_function: sleep)
+      on_exit(fn -> ExternalService.stop(name) end)
+
+      ExternalService.call(name, fn -> :ok end)
+      ExternalService.call(name, fn -> :ok end)
+
+      assert_received {:telemetry, [:external_service, :rate_limit, :sleep],
+                       %{sleep_time: sleep_time}, %{service: ^name}}
+
+      assert is_integer(sleep_time)
+    end
+  end
+
   # Trips a service's circuit breaker by melting it past its configured tolerance.
   defp blow_fuse(name) do
     ExternalService.call(name, %RetryOptions{backoff: {:linear, 0, 1}}, fn -> :retry end)
+  end
+
+  # Starts a service with a high failure tolerance (so it won't blow) unless
+  # overridden, registers cleanup, and returns its name.
+  defp start_fuse(name, options \\ [fuse_strategy: {:standard, 100, 10_000}]) do
+    ExternalService.start(name, options)
+    on_exit(fn -> ExternalService.stop(name) end)
+    name
   end
 end

--- a/test/external_service_test.exs
+++ b/test/external_service_test.exs
@@ -438,6 +438,52 @@ defmodule ExternalServiceTest do
     end
   end
 
+  describe "retry options" do
+    test "max_attempts limits the total number of attempts" do
+      name = start_fuse(:"max-attempts-test")
+      Process.put(:count, 0)
+      opts = %RetryOptions{backoff: {:linear, 0, 1}, max_attempts: 3}
+
+      result =
+        ExternalService.call(name, opts, fn ->
+          Process.put(:count, Process.get(:count) + 1)
+          :retry
+        end)
+
+      assert Process.get(:count) == 3
+      assert result == {:error, {:retries_exhausted, :reason_unknown}}
+    end
+
+    test "max_attempts of 1 makes a single attempt with no retries" do
+      name = start_fuse(:"max-attempts-one")
+      Process.put(:count, 0)
+      opts = %RetryOptions{backoff: {:linear, 0, 1}, max_attempts: 1}
+
+      ExternalService.call(name, opts, fn ->
+        Process.put(:count, Process.get(:count) + 1)
+        :retry
+      end)
+
+      assert Process.get(:count) == 1
+    end
+
+    test "jitter affects only delay, not the attempt count" do
+      for randomize <- [true, 0.5] do
+        name = start_fuse(:"jitter-test-#{inspect(randomize)}")
+        counter = {:jitter_count, randomize}
+        Process.put(counter, 0)
+        opts = %RetryOptions{backoff: {:linear, 0, 1}, randomize: randomize, max_attempts: 3}
+
+        ExternalService.call(name, opts, fn ->
+          Process.put(counter, Process.get(counter) + 1)
+          :retry
+        end)
+
+        assert Process.get(counter) == 3
+      end
+    end
+  end
+
   describe "introspection" do
     setup do
       name = :"introspection-test"


### PR DESCRIPTION
Third milestone on the road to 2.0 (see `ROADMAP.md`). Three independent, **additive** features — reviewable commit-by-commit. No breaking changes.

### 1. Circuit breaker introspection (issue #5) — `64184fe`
Query breaker state without making a call, to implement the circuit-breaker pattern (bail out early when a dependency is down):
- `ExternalService.available?/1`, `blown?/1`, `all_available?/1`
- `available?/0` and `blown?/0` on `use ExternalService.Gateway` modules

A service that was never started is reported as not available and not blown.

### 2. Telemetry events — `2526d95`
`:telemetry` events around guarded calls, all carrying the `:service` (fuse) name:
- `[:external_service, :call, :start | :stop | :exception]` — a span; `:stop` includes the call `:result`
- `[:external_service, :call, :retry]` — an attempt failed and melted the breaker
- `[:external_service, :circuit_breaker, :blown]` — call rejected by an open breaker
- `[:external_service, :rate_limit, :sleep]` — call throttled, with the sleep duration

Event names use the terminology we're standardizing on (`circuit_breaker`) so they remain stable through the later M4 config rename. Documented in the `ExternalService` moduledoc.

### 3. Count-based retries + explicit jitter — `8aee133`
- `RetryOptions.max_attempts` — bound total attempts (initial + retries), complementing time-based `:expiry`
- `RetryOptions.randomize` now also accepts a float jitter proportion (e.g. `0.25`) in addition to `true`/`false`. Fixes a latent issue where `randomize: true` would have been passed to `Retry.DelayStreams.randomize/2` (which expects a number)
- `apply_retry_options/1` rewritten with explicit ordered helpers replacing an order-dependent `Map.take/reduce`

## Verification
- `mix test` — 60 tests, 0 failures (verified across multiple seeds)
- `mix format --check-formatted`, `mix credo --strict`, `mix compile --warnings-as-errors`, `mix dialyzer`, `mix docs` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)