### PR TITLE
M5: documentation overhaul — guides, cheatsheet, migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 Work toward 2.0 (see `ROADMAP.md`). The 2.0 line modernizes the project and
-introduces breaking changes; a migration guide will accompany the release.
+introduces breaking changes. See the
+[migration guide](guides/migrating-to-2.0.md) for a step-by-step upgrade from
+1.x.
 
 ### Added
+- Documentation overhaul: a set of guides (Getting Started, the module front
+  door, circuit breakers, retries, rate limiting, error handling, telemetry), a
+  cheatsheet, and a step-by-step [migration guide](guides/migrating-to-2.0.md),
+  all published on HexDocs.
 - Introspection for circuit breaker state ([issue #5](https://github.com/jvoegele/external_service/issues/5)):
   `ExternalService.available?/1`, `ExternalService.blown?/1`, and
   `ExternalService.all_available?/1`, plus `available?/0` and `blown?/0` on
@@ -53,8 +59,8 @@ introduces breaking changes; a migration guide will accompany the release.
   | raise `ExternalService.FuseNotFoundError` | raise `ExternalService.ServiceNotStarted` |
 
   Results returned directly by the wrapped function (including its own
-  `{:error, reason}` values) are unchanged. A full migration guide will ship with
-  2.0.
+  `{:error, reason}` values) are unchanged. See the
+  [migration guide](guides/migrating-to-2.0.md) for the full mapping.
 - **Configuration and terminology overhauled** to drop the leaked "fuse" wording:
   - `start/2` now takes `circuit_breaker: [tolerate:, within:, reset:, fault_injection:]`
     and `rate_limit: [limit:, per:]` (and an optional `retry:`) instead of

--- a/README.md
+++ b/README.md
@@ -1,267 +1,117 @@
 # ExternalService
 
-An Elixir library for safely using external service or API using customizable retry logic, automatic rate limiting, and the circuit breaker pattern. Calls to external services can be synchronous, asynchronous background tasks, or multiple calls can be made in parallel for MapReduce style processing.
-
-## Overview
-
-`ExternalService` is, in essence, the combination of two techniques: retrying individual requests that have failed and preventing cascading failures with circuit breakers. The basic approach to using `ExternalService` is to wrap all usages of any external services in an Elixir function and pass this function to the `ExternalService.call` function, together with some options that control the retry mechanism. By doing so, `ExternalService` can manage calls to the external API that you’re using, and apply retry logic to individual calls while ensuring that your application is protected from outages or other problems with the external API by using “circuit breakers” (described in more detail below).
-
-In addition to the `call` function, `ExternalService` also provides a `call_async` function, which uses an Elixir Task to call the external service asynchronously, and a `call_async_stream` function, which makes multiple calls to the external service in parallel.
-
-Both of these functions apply the same retry and “circuit breaker” mechanisms as the regular call function. Let’s look at these mechanisms in further detail.
-
-### Retrying failed requests
-
-Many of the failures that occur when accessing external services are transient in nature. For example, there could be network congestion causing a request to timeout, or the service could be under heavy load and is not able to handle any more requests at the time. The best strategy for dealing with such transient failures is to simply retry the failed request – perhaps after a brief backoff period. The `external_service` package uses the [retry library](https://hex.pm/packages/retry) from Safwan Kamarrudin to automate retry logic. This retry library provides flexible configuration to control various aspects of retry logic, such as whether to use linear or exponential backoff, the maximum delay between retries, and the total amount of time to spend retrying before giving up.
-
-### Circuit breakers for preventing catastrophic cascade
-
-The Circuit Breaker pattern was first described in Michael Nygard's landmark book [Release It!](https://pragprog.com/book/mnee/release-it) and was later popularized by Martin Fowler on his [bliki post](https://martinfowler.com/bliki/CircuitBreaker.html). To quote Nygard, “Circuit breakers are a way to automatically degrade functionality when the system is under stress.”
-
-The Circuit Breaker pattern is modeled after electrical circuit breakers, which are designed to protect electrical circuits from damage caused by excess current. Like these electrical circuit breakers, software “circuit breakers” are designed to protect the system at large from damage caused by faults in a component of the system. By protecting calls to external services, the circuit breaker can monitor for failures. If the failures reach some given threshold, the circuit breaker “trips” and further calls to the service will immediately return an error without even making a call to the external API itself. After a configurable period of time, the circuit breaker is automatically reset and calls to the external service will once again be attempted with the same monitoring as before.
-
-In contrast to retry logic, which is applied to each individual call to a service, the circuit breaker for a given service is global to the entire system. If a circuit trips, then it trips for all users of the associated service. This is a key feature of the Circuit Breaker pattern, and is what allows it to prevent cascading failures.
-
-The `external_service` package uses the [Erlang fuse library](https://github.com/jlouis/fuse) from Jesper Louis Andersen for implementing circuit breakers. To extend the electrical analogies, circuit breakers in the fuse library are called “fuses.” These fuses can be used to protect against cascading failure by first asking the fuse if it is OK to proceed using the `:fuse.ask` function. If this function returns `:ok` then it is OK to proceed to calling on the external service. If, on the other hand, it returns `:blown`, then the fuse has been tripped and it is not safe to call the external service. In this scenario, your code must have a fallback option to compensate for the fact that the external service is unavailable, which might mean returning cached data or indicating to the user that the functionality is not currently available.
-
-What causes a fuse to trip?
-When using a fuse, your application code must tell the fuse about any failures that occur. If you’ve asked the fuse if it is OK to proceed but then receive an error from the external service, your code should call the `:fuse.melt` function, which “melts the fuse a little bit”. Once the fuse has been “melted” enough times, the fuse is tripped and future calls to `:fuse.ask` for that fuse will return `:blown`.
-
-ExternalService wraps the functionality provided by fuse in a convenient interface and automates the handling of the fuse so that you don’t need to explicitly call `:fuse.ask` or `:fuse.melt` in your code. Instead, you simply use the ExternalService.call function with the name of the fuse as the first argument, together with the function in which you’ve wrapped your call to the external API. Then, the ExternalService.call function will first ask the given fuse before making the call and will return `{:error, :fuse_blown}` if the fuse is blown. It will also automatically call `:fuse.melt` any time the call to the given function results in a retry. This eventually results in a blown fuse if there are enough failed requests to the service being protected by the fuse.
-
-The only requirement for using a fuse for a particular service is that it must be initialized before using the service. This is done with the `ExternalService.start/2` function, which takes the fuse name and options as arguments. The fuse name is an atom which must uniquely identify the external service to which the fuse applies. This function should be called in your application startup code, which is typically the `Application.start` function for your application.
-
-### Rate Limiting
-
-Since version 0.8.0, `ExternalService` allows for rate limiting of calls to a service by specifying the rate limit as an optional argument to `ExternalService.start`. If the `rate_limit` option is passed to `ExternalService.start`, then all calls to the external service will be automatically rate-limited. Once the number of calls to the external service has exceeded the limits for a given time window, then `ExternalService` will delay the call to the service until the time window has expired and calls to the service are allowed again. By default, the delay is accomplished using Elixir's `Process.sleep/1` function, so if you are using `ExternalService.call` then the calling process is put to sleep for the specified time window. If, on the other hand, you are using `ExternalService.call_async` or `ExternalService.call_async_stream`, then it is the background process(es) that are put to sleep, and the calling process is _not_ put to sleep in this case. The sleep function can be configured by passing the `:sleep_function` option to `ExternalService.start`. In any case, the rate-limiting is applied to all calls to a particular service across your application so that you can rest assured that you will not violate the rate limits imposed by the external service that you are calling.
-
-Applying rate limits to an external service is as simple as specifying the limits in `ExternalService.start`, as in the following example, which limits calls to `:some_external_service` a maximum of 10 times per second:
-
-```elixir
-ExternalService.start(:some_external_service, rate_limit: {10, 1000})
-```
-
-## Usage Examples
-
-Below are some example usages of `ExternalService` that illustrate how to configure fuses and retries, and how to use the various forms of the `call` functions for using an external service reliably. Some of the examples are adapted from the Ropig code base that was the original use case for `ExternalService`, and they show how to use `ExternalService` for interacting with Google's `Pub/Sub` messaging service.
-
-### Fuse initialization
-
-This example shows how to initialize the fuse for a service, as well as how to apply automatic rate limiting to that service.
-
-```elixir
-defmodule PubSub do
-  @fuse_name __MODULE__
-  @fuse_options [
-    # Tolerate 5 failures for every 1 second time window.
-    fuse_strategy: {:standard, 5, 1_000},
-    # Reset the fuse 5 seconds after it is blown.
-    fuse_refresh: 5_000,
-    # Limit to 100 calls per second.
-    rate_limit: {100, 1_000}
-  ]
-
-  def start do
-    ExternalService.start(@fuse_name, @fuse_options)
-  end
-end
-```
-
-### Triggering a retry
-
-This example illustrates the usage of the `ExternalService.call` function and some of the retry options that can be used to control retry behavior. Notice how we delegate to a named function in `call`.
-
-```elixir
-defmodule PubSub do
-  @retry_errors [
-    408, # TIMEOUT
-    429, # RESOURCE_EXHAUSTED
-    499, # CANCELLED
-    500, # INTERNAL
-    503, # UNAVAILABLE
-    504, # DEADLINE_EXCEEDED
-  ]
-  @retry_opts %ExternalService.RetryOptions{
-    # Use linear backoff. Exponential backoff is also available.
-    backoff: {:linear, 100, 1},
-    # Stop retrying after 5 seconds.
-    expiry: 5_000,
-  }
-
-  def publish(message, topic) do
-    ExternalService.call(PubSub, @retry_opts, fn -> try_publish(message, topic) end)
-  end
-
-  defp try_publish(message, topic) do
-    message
-    |> Kane.Message.publish(%Kane.Topic{name: topic})
-    |> case do
-      {:error, reason, code} when code in @retry_errors ->
-        {:retry, reason}
-      kane_result ->
-        # If not a retriable error, just return the result.
-        kane_result
-    end
-  end
-end
-```
-
-We wrap our call to the external service in a function and pass this function to `ExternalService.call` with retry options as the second argument. Importantly, we use a special return value from our anonymous function to trigger a retry. A retry is triggered by one of three mechanisms:
-
-1. the function returns `:retry`
-1. the function returns a tuple of the form `{:retry, reason}`
-1. the function raises an Elixir `RuntimeError`, or another exception type specified in the `rescue_only` option
-
-In our example code, we examine the result of calling Kane.Message.publish and if it is an error response with an error code that matches one of our predetermined `@retry_errors`, we then trigger a retry.
-
-Not all failed requests should be retried, of course. Some failures are due to bugs in the calling code; such calls can never succeed and therefore should not be retried. In our case, we consulted the documentation for Google Pub/Sub to determine which error codes should result in a retry. You will have to decide on a strategy to determine what error conditions are retriable for your service.
-
-### Error handling
-
-Although the retry mechanism goes a long way towards eliminating transient failures, there will be times when a service is unavailable for a long enough time that retries ultimately fail. If, for example, a request has been retried several times and the time spent on retries exceeds the configured `expiry` time for that request, then `ExternalService.call` will give up and return the tuple `{:error, :retries_exhausted}`.
-
-Another failure scenario is when there are many different processes using an external service concurrently, such as for example many different web requests. If the service or API being used is temporarily unable to handle requests, then all of these concurrent calls to the service will eventually trip the circuit breaker associated with that external service. Then, `ExternalService.call` will return the tuple `{:error, :fuse_blown}`. Further calls to the service at this point would immediately result in the `{:error, :fuse_blown}` until the fuse is reset, which happens automatically after the configured `fuse_refresh` time for the fuse.
-
-It is up to the caller to determine how to handle these errors. A web application might, for example, log the error and return a *503 Service Unavailable* status code. Background jobs could log the error and pause until the service is fully functioning again. This example shows a Phoenix controller that uses the `PubSub.publish` function from above and handles failed requests by returning a *503* status code.
-
-```elixir
-defmodule MyApp.MyController do
-  use MyAppWeb, :controller
-  require Logger
-
-  @topic "some_topic"
-
-  def create(conn, %{"message" => message}) do
-    case PubSub.publish(message, @topic) do
-      {:ok, _result} ->
-        send_resp(conn, 201, "")
-
-      {:error, {:retries_exhausted, reason}} ->
-        Logger.error("Retries exhausted while trying to publish to #{@topic}: #{inspect(reason)}")
-        send_resp(conn, 503, "")
-
-      {:error, {:fuse_blown, fuse_name}} ->
-        Logger.error("Fuse blown while trying to publish to #{@topic}: #{inspect(fuse_name)}")
-        send_resp(conn, 503, "")
-
-      error ->
-        # If we got here it means that we did not an :ok response from Kane, nor did we get one of
-        # the error tuples meaning retries_exhausted or fuse_blown, so it must be some other kind
-        # of non-retriable error response from Kane itself. Log the error and send back a 503.
-        Logger.error("Unknown error while trying to publish to #{@topic}: #{inspect(error)}")
-        send_resp(conn, 503, "")
-    end
-  end
-end
-```
-
-### Cleaning up error handling with `ExternalService.call!`
-
-As seen in the above example, error handling code can be somewhat intricate because we must distinguish between error responses that are created by `ExternalService.call` versus responses that originate from the service itself. In cases like this it can be useful to use `ExternalService.call!` so that error responses created by `ExternalService` are raised as exceptions instead of returned as error tuples. To show how this works, let's add a new `publish!` function to the `PubSub` module, which is just like `publish` except that it uses `call!` instead of `call`.
-
-```elixir
-defmodule PubSub do
-  # same @retry_errors and @retry_opts from above example...
-
-  # Will raise a `RetriesExhaustedError` or `FuseBlownError` in event of failure.
-  def publish!(message, topic) do
-    ExternalService.call!(PubSub, @retry_opts, fn -> try_publish(message, topic) end)
-  end
-end
-```
-
-Now let's see how this impacts our calling code in the hypothetical controller:
-
-```elixir
-defmodule MyApp.MyController do
-  use MyAppWeb, :controller
-  require Logger
-
-  @topic "some_topic"
-
-  def create(conn, %{"message" => message}) do
-    try do
-      case PubSub.publish!(message, @topic) do
-        {:ok, _result} ->
-          send_resp(conn, 201, "")
-
-        error ->
-          Logger.error("Unknown error while trying to publish to #{@topic}: #{inspect(error)}")
-          send_resp(conn, 503, "")
-      end
-    rescue
-      e in [ExternalService.RetriesExhaustedError, ExternalService.FuseBlownError] ->
-        Logger.error(Exception.format(:error, e))
-        send_resp(conn, 503, "")
-    end
-  end
-end
-```
-
-By using `call!`, it is much more apparent which kinds of errors are coming from the actual service being used, rather than those that are created by `ExternalService`.
-
-### Asynchronous calls
-
-In addition to the [`call`](https://hexdocs.pm/external_service/ExternalService.html#call/3) function demonstrated above, the `ExternalService` module also provides `call_async` and `call_async_stream`:
-
-* [`call_async`](https://hexdocs.pm/external_service/ExternalService.html#call_async/3) - asynchronous version of `call` that returns an Elixir `Task` that can be used to retrieve the result
-* [`call_async_stream`](https://hexdocs.pm/external_service/ExternalService.html#call_async_stream/5) - parallel, streaming version of `call` that is modeled after Elixir's built-in `Task.async_stream` function
-
-Both of these asynchronous functions apply the same retry and circuit breaker mechanisms as the synchronous `call` function, so any necessary retries are performed transparently in the background task(s).
-
-In the code examples that follow, these asynchronous forms of `call` are illustrated using the same `@retry_errors`, `@retry_opts`, and `try_publish/2` function from the previous example above.
-
-```elixir
-defmodule PubSub do
-  # same @retry_errors and @retry_opts from above example...
-
-  # Returns an Elixir `Task`, which can be used to retrieve the result,
-  # using `Task.await`, for example.
-  def publish_async(message, topic) do
-    ExternalService.call_async(PubSub, @retry_opts, fn -> try_publish(message, topic) end)
-  end
-
-  # Publish many messages in parallel and return a Stream of results as described by `Task.async_stream`.
-  def publish_async_stream(messages, topic) when is_list(messages) do
-    ExternalService.call_async_stream(messages, PubSub, @retry_opts, fn message ->
-      try_publish(message, topic)
-    end)
-  end
-end
-```
-
-Using the async version is a simple means of achieving paralellism since other work can be accomplished while the external calls are taking place. For example:
-
-```elixir
-task = PubSub.publish_async("Hello", "world")
-do_other_things()
-case Task.await(task) do
-  {:ok, _result} ->
-    :ok
-  {:error, {:retries_exhausted, reason}} ->
-    :error
-  {:error, {:fuse_blown, fuse_name}} ->
-    :error
-end
-```
-
-## Documentation
-
-See [my blog post](https://ropig.com/blog/use-external-services-safely-reliably-elixir-applications/) for overview documentation, and then check out the [API reference](https://hexdocs.pm/external_service/api-reference.html) for full details.
+[![Hex.pm](https://img.shields.io/hexpm/v/external_service.svg)](https://hex.pm/packages/external_service)
+[![Documentation](https://img.shields.io/badge/docs-hexdocs-blue.svg)](https://hexdocs.pm/external_service)
+
+An Elixir library for safely calling external services and APIs with
+customizable **retry logic**, the **circuit breaker** pattern, and optional
+**rate limiting**. Calls can be synchronous, asynchronous background tasks, or
+fanned out in parallel for MapReduce-style processing — all under the same
+protection.
+
+## Why?
+
+Calling an external service is risky: the network hiccups, the service is briefly
+overloaded, or it goes down entirely. `ExternalService` wraps those calls with
+three complementary safety mechanisms:
+
+- **Retries** smooth over *transient* failures by trying again with configurable
+  backoff and jitter.
+- A **circuit breaker** protects against a *persistently* failing service: once
+  failures cross a threshold the breaker opens and calls fail fast instead of
+  piling up against a service that is already down.
+- A **rate limiter** keeps you under the call quota the service imposes.
+
+You wrap your call in a function, hand it to `ExternalService`, and all of the
+above is applied on every call.
 
 ## Installation
 
-`external_service` is [available in Hex](https://hex.pm/packages/external_service), and can be installed
-by adding `external_service` to your list of dependencies in `mix.exs`:
+Add `external_service` to your dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:external_service, "~> 1.1.3"}]
+  [{:external_service, "~> 2.0"}]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/external_service](https://hexdocs.pm/external_service).
+## Quick start
 
-Sponsored by Ropig http://ropig.com
+Define a module for the service, configuring it declaratively, and start it
+under your supervisor:
+
+```elixir
+defmodule MyApp.Stripe do
+  use ExternalService,
+    circuit_breaker: [tolerate: 5, within: :timer.seconds(1), reset: :timer.seconds(5)],
+    rate_limit: [limit: 100, per: :timer.seconds(1)],
+    retry: [max_attempts: 5, backoff: :exponential, jitter: true]
+
+  def charge(params) do
+    call fn ->
+      case Stripe.charge(params) do
+        {:ok, result} -> {:ok, result}
+        {:error, %{status: status}} when status in 500..599 -> :retry
+        other -> other
+      end
+    end
+  end
+end
+```
+
+```elixir
+# In your supervision tree:
+children = [MyApp.Stripe]
+Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)
+```
+
+Now call it from anywhere; retries, circuit breaking, and rate limiting are
+applied automatically:
+
+```elixir
+case MyApp.Stripe.charge(%{amount: 1000, currency: "usd", source: token}) do
+  {:ok, result} ->
+    handle_success(result)
+
+  {:error, %ExternalService.RetriesExhausted{}} ->
+    {:error, :payment_unavailable}
+
+  {:error, %ExternalService.CircuitBreakerOpen{}} ->
+    {:error, :payment_unavailable}
+
+  {:error, reason} ->
+    {:error, reason}
+end
+```
+
+Inside the function you pass to `call/1`, return `:retry` or `{:retry, reason}`
+to ask for another attempt; any other value is treated as success and returned
+as-is.
+
+## Documentation
+
+Full documentation is on [HexDocs](https://hexdocs.pm/external_service). Start
+with these guides:
+
+- **[Getting Started](guides/getting-started.md)** — your first reliable call.
+- **[The Module Front Door](guides/the-front-door.md)** — everything `use
+  ExternalService` generates, plus supervision and overrides.
+- **[Circuit Breakers](guides/circuit-breakers.md)** — how the breaker trips,
+  resets, and how to introspect it.
+- **[Retries](guides/retries.md)** — backoff, jitter, attempt/time budgets, and
+  retrying on exceptions.
+- **[Rate Limiting](guides/rate-limiting.md)** — staying under a quota.
+- **[Error Handling](guides/error-handling.md)** — `call` vs `call!` and the
+  structured error types.
+- **[Telemetry](guides/telemetry.md)** — observing calls, retries, and trips.
+- **[Migrating to 2.0](guides/migrating-to-2.0.md)** — upgrading from 1.x.
+
+## Upgrading from 1.x
+
+Version 2.0 is a breaking modernization of the library. See the
+[migration guide](guides/migrating-to-2.0.md) and the
+[CHANGELOG](CHANGELOG.md) for the full list of changes.
+
+## License
+
+Released under the Apache 2.0 license. Originally sponsored by Ropig.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,12 +117,15 @@ MyApp.Stripe.reset()
 > Circuit-breaker melt semantics intentionally unchanged: a failure still melts the
 > breaker; `:retry_on` only governs whether the attempt is retried.
 
-### M5 — Documentation overhaul
-- [ ] Split the README into `guides/` (mirror Bond): getting-started, circuit
-      breakers, retries, rate limiting, gateways, telemetry, error handling,
-      migrating-to-2.0, about/history.
-- [ ] ExDoc cheatsheets for retry/circuit-breaker recipes.
-- [ ] `mix.exs` docs config with `extras` + `filter_modules` (internal: true).
+### M5 — Documentation overhaul ✓
+- [x] Split the README into `guides/` (mirror Bond): getting-started, the module
+      front door, circuit breakers, retries, rate limiting, error handling,
+      telemetry, migrating-to-2.0, about/history. README slimmed to a 2.0-accurate
+      overview that links into the guides.
+- [x] ExDoc cheatsheet (`guides/cheatsheet.cheatmd`) for retry/circuit-breaker recipes.
+- [x] `mix.exs` docs config with `extras` + `groups_for_extras` + `filter_modules`
+      (internal: true); `main` now the Getting Started guide.
+- [x] Wrote the 1.x → 2.0 migration guide the CHANGELOG references.
 
 ### M6 — Release prep
 - [ ] CHANGELOG, migration guide, deprecation warnings on 1.x paths.

--- a/guides/about.md
+++ b/guides/about.md
@@ -4,9 +4,9 @@
 APIs, combining three well-established reliability techniques behind one small
 interface:
 
-  * **Retries** for transient failures,
-  * the **Circuit Breaker** pattern for persistent failures, and
-  * **rate limiting** for staying within a service's quota.
+- **Retries** for transient failures,
+- the **Circuit Breaker** pattern for persistent failures, and
+- **rate limiting** for staying within a service's quota.
 
 Calls can be synchronous, asynchronous background tasks, or fanned out in
 parallel for MapReduce-style processing — all under the same retry, circuit
@@ -26,7 +26,7 @@ both attempt-count and time budgets — using
 
 ### Circuit breakers
 
-The Circuit Breaker pattern was first described in Michael Nygard's *Release It!*
+The Circuit Breaker pattern was first described in Michael Nygard's _Release It!_
 and later popularized by Martin Fowler. To quote Nygard, "Circuit breakers are a
 way to automatically degrade functionality when the system is under stress."
 

--- a/guides/about.md
+++ b/guides/about.md
@@ -1,0 +1,69 @@
+# About ExternalService
+
+`ExternalService` is an Elixir library for safely calling external services and
+APIs, combining three well-established reliability techniques behind one small
+interface:
+
+  * **Retries** for transient failures,
+  * the **Circuit Breaker** pattern for persistent failures, and
+  * **rate limiting** for staying within a service's quota.
+
+Calls can be synchronous, asynchronous background tasks, or fanned out in
+parallel for MapReduce-style processing — all under the same retry, circuit
+breaker, and rate-limiting protection.
+
+## The ideas
+
+### Retrying failed requests
+
+Many failures when accessing an external service are transient: network
+congestion causing a timeout, or a service briefly under heavy load. The best
+response is often simply to try again after a short backoff. `ExternalService`
+automates retry logic — linear or exponential backoff, jitter, delay caps, and
+both attempt-count and time budgets — using
+[Safwan Kamarrudin's retry library](https://hex.pm/packages/retry). See
+[Retries](retries.md).
+
+### Circuit breakers
+
+The Circuit Breaker pattern was first described in Michael Nygard's *Release It!*
+and later popularized by Martin Fowler. To quote Nygard, "Circuit breakers are a
+way to automatically degrade functionality when the system is under stress."
+
+Like the electrical breakers they're named for, software circuit breakers protect
+a system from damage caused by a faulty component. By monitoring calls to an
+external service, a breaker can "trip" once failures cross a threshold, after
+which further calls fail fast instead of piling up against a service that is
+already in trouble. After a cool-down it resets and calls resume. Crucially, the
+breaker is global to the service, so a trip protects every caller at once and
+prevents cascading failures.
+
+`ExternalService` implements circuit breakers on top of
+[Jesper Louis Andersen's Erlang fuse library](https://github.com/jlouis/fuse),
+managing the underlying fuse for you — you never call `:fuse.ask` or
+`:fuse.melt` yourself. See [Circuit breakers](circuit-breakers.md).
+
+### Rate limiting
+
+Many services impose a request quota. `ExternalService` can keep you under it
+automatically and application-wide, using
+[ex_rated](https://hex.pm/packages/ex_rated): excess calls sleep until the window
+allows them, rather than failing. See [Rate limiting](rate-limiting.md).
+
+## History
+
+`ExternalService` grew out of production code at Ropig, where it was first used
+to make reliable calls to Google's Pub/Sub messaging service. It was one of
+author Jason Voegele's first open-source Elixir libraries and went on to see wide
+production adoption. The original overview is described in
+[this blog post](https://ropig.com/blog/use-external-services-safely-reliably-elixir-applications/).
+
+The 2.0 line is a ground-up modernization of that original library — validated
+and self-documenting options, telemetry, circuit-breaker introspection,
+structured errors, and a declarative module front door (`use ExternalService`) —
+while keeping the core idea unchanged: wrap a call in a function, hand it over,
+and let retries, the circuit breaker, and rate limiting just work.
+
+## License
+
+`ExternalService` is released under the Apache 2.0 license.

--- a/guides/cheatsheet.cheatmd
+++ b/guides/cheatsheet.cheatmd
@@ -1,0 +1,189 @@
+# ExternalService Cheatsheet
+
+Quick recipes for configuring and calling services. See the guides for full
+detail.
+
+## Define a service
+{: .col-2}
+
+### Module front door (recommended)
+
+```elixir
+defmodule MyApp.Api do
+  use ExternalService,
+    circuit_breaker: [tolerate: 5, within: :timer.seconds(1), reset: :timer.seconds(5)],
+    rate_limit: [limit: 100, per: :timer.seconds(1)],
+    retry: [max_attempts: 5, backoff: :exponential, jitter: true]
+
+  def fetch(id), do: call(fn -> HTTP.get("/things/#{id}") end)
+end
+```
+
+Start it under a supervisor:
+
+```elixir
+children = [MyApp.Api]
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+### Functional API
+
+```elixir
+ExternalService.start(:payments,
+  circuit_breaker: [tolerate: 5, within: 1_000, reset: 5_000],
+  retry: [max_attempts: 3]
+)
+
+ExternalService.call(:payments, fn -> charge() end)
+```
+
+## Calling
+{: .col-2}
+
+### Synchronous
+
+```elixir
+MyApp.Api.call(fn -> work() end)
+MyApp.Api.call([max_attempts: 2], fn -> work() end)  # per-call retry opts
+MyApp.Api.call!(fn -> work() end)                     # raises on failure
+```
+
+### Async / parallel
+
+```elixir
+task = MyApp.Api.call_async(fn -> work() end)
+Task.await(task)
+
+ids
+|> MyApp.Api.call_async_stream(fn id -> fetch(id) end)
+|> Enum.to_list()
+```
+
+## Triggering retries
+{: .col-2}
+
+### Return values
+
+```elixir
+call fn ->
+  case HTTP.get(url) do
+    {:ok, %{status: 200} = r}            -> {:ok, r}
+    {:ok, %{status: s}} when s in 500..599 -> {:retry, s}  # retry
+    {:ok, %{status: 429}}                -> :retry          # retry
+    other                                -> other           # success
+  end
+end
+```
+
+### Key rule
+
+| Return | Effect |
+| --- | --- |
+| `:retry` | retry |
+| `{:retry, reason}` | retry (reason recorded) |
+| anything else | success, returned as-is |
+| raised exception | propagates (retried only if in `:retry_on`) |
+
+## Circuit breaker config
+{: .col-2}
+
+### Options
+
+```elixir
+circuit_breaker: [
+  tolerate: 5,                # failures per window (default 10)
+  within: :timer.seconds(1),  # window ms (default 10_000)
+  reset: :timer.seconds(5)    # ms open before reset (default 60_000)
+]
+```
+
+### Introspect & reset
+
+```elixir
+MyApp.Api.available?()   # breaker closed?
+MyApp.Api.blown?()       # breaker open?
+MyApp.Api.reset()        # force closed
+
+ExternalService.all_available?([:a, :b])
+```
+
+## Retry options
+{: .col-2}
+
+### All options
+
+```elixir
+retry: [
+  backoff: :exponential,   # or :linear
+  base: 100,               # initial delay ms (default 10)
+  factor: 1,               # :linear growth factor
+  cap: :timer.seconds(2),  # max single delay
+  max_attempts: 5,         # attempt count bound
+  expiry: :timer.seconds(10), # time budget ms
+  jitter: true,            # ±10%, or a float proportion
+  retry_on: []             # exception modules to retry
+]
+```
+
+### Recipes
+
+```elixir
+# Fast, bounded
+retry: [max_attempts: 3, backoff: :linear, base: 50]
+
+# Resilient HTTP default
+retry: [backoff: :exponential, base: 100, cap: 2_000,
+        max_attempts: 5, jitter: true]
+
+# Retry a transient exception
+retry: [retry_on: [MyApp.TransientError]]
+```
+
+## Error handling
+{: .col-2}
+
+### Returned by `call`
+
+```elixir
+case MyApp.Api.fetch(id) do
+  {:ok, v} -> v
+  {:error, %ExternalService.RetriesExhausted{}} -> degrade()
+  {:error, %ExternalService.CircuitBreakerOpen{}} -> degrade()
+  {:error, reason} -> {:error, reason}  # your own error
+end
+```
+
+### Raised by `call!`
+
+```elixir
+rescue
+  e in [ExternalService.RetriesExhausted,
+        ExternalService.CircuitBreakerOpen] ->
+    send_resp(conn, 503, "")
+```
+
+## Telemetry events
+{: .col-2}
+
+### Events
+
+```text
+[:external_service, :call, :start]
+[:external_service, :call, :stop]
+[:external_service, :call, :exception]
+[:external_service, :call, :retry]
+[:external_service, :circuit_breaker, :blown]
+[:external_service, :rate_limit, :sleep]
+```
+
+### Attach
+
+```elixir
+:telemetry.attach_many(
+  "es-handler",
+  [[:external_service, :call, :retry],
+   [:external_service, :circuit_breaker, :blown]],
+  &MyApp.Telemetry.handle/4,
+  nil
+)
+```

--- a/guides/circuit-breakers.md
+++ b/guides/circuit-breakers.md
@@ -1,0 +1,146 @@
+# Circuit Breakers
+
+The circuit breaker is what protects your application from a *persistently*
+failing dependency. Where retries handle the occasional blip, the breaker
+handles the outage: once a service fails too often, the breaker "opens" and
+further calls fail fast — immediately, without touching the struggling service —
+until it has had time to recover.
+
+This is the mechanism described in Michael Nygard's *Release It!* and popularized
+by Martin Fowler. `ExternalService` implements it on top of the Erlang
+[`:fuse`](https://github.com/jlouis/fuse) library, but you never call `:fuse`
+directly — the breaker is managed for you on every call.
+
+## Why fail fast?
+
+When a dependency is down and you keep calling it, every caller blocks on
+timeouts, work piles up, and the failure spreads — a *cascading* failure. The
+breaker short-circuits that: after enough failures it stops you from even
+attempting the call, so callers get an immediate error they can handle (serve
+cached data, degrade gracefully, return 503) instead of hanging.
+
+Unlike retries, which are per-call, the breaker is **global to the service**. If
+it trips, it trips for every caller in the system at once. That is precisely what
+makes it effective at preventing cascades.
+
+## Configuration
+
+Configure the breaker with the `:circuit_breaker` option to `use
+ExternalService` or `ExternalService.start/2`:
+
+```elixir
+use ExternalService,
+  circuit_breaker: [
+    tolerate: 5,                 # failures allowed within the window...
+    within: :timer.seconds(1),   # ...this window, in milliseconds
+    reset: :timer.seconds(5)     # stay open this long before resetting
+  ]
+```
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `:tolerate` | `10` | Number of failures tolerated within the `:within` window before the breaker opens. |
+| `:within` | `10_000` | Length of the failure-counting window, in milliseconds. |
+| `:reset` | `60_000` | Milliseconds to wait before the breaker resets (closes) after opening. |
+| `:fault_injection` | — | If set to a rate between `0.0` and `1.0`, randomly fails that fraction of calls (for testing). |
+
+So `tolerate: 5, within: 1_000` means "open the breaker once there are more than
+5 failures inside any 1-second window." After opening, the breaker stays open
+for `:reset` milliseconds, then closes again and calls resume under the same
+monitoring.
+
+The `:circuit_breaker` option (and every key within it) is optional. Omit it to
+get the defaults above.
+
+## What counts as a failure?
+
+The breaker is "melted" — pushed one step toward opening — on every call attempt
+that fails, where a failure is:
+
+  * the function returns `:retry` or `{:retry, reason}`, or
+  * the function raises an exception.
+
+> #### Melt vs. retry {: .info}
+>
+> A failure melts the breaker **whether or not the call is retried**. The
+> `:retry_on` retry option governs whether a *raised exception* triggers another
+> attempt; it does not change what melts the breaker. A raised exception that is
+> not retried still melts the breaker and then propagates to the caller.
+
+Values your function simply returns — including its own `{:error, reason}` — are
+successes as far as the breaker is concerned and do not melt it.
+
+## When the breaker is open
+
+A call made while the breaker is open does not invoke your function at all.
+Instead:
+
+  * `call/3` returns `{:error, %ExternalService.CircuitBreakerOpen{}}`,
+  * `call!/3` raises `ExternalService.CircuitBreakerOpen`, and
+  * an `[:external_service, :circuit_breaker, :blown]` telemetry event is
+    emitted.
+
+See [Error handling](error-handling.md) for how to deal with these.
+
+## Introspecting and resetting
+
+You can ask about the breaker's state at any time. With the module front door:
+
+```elixir
+MyApp.Stripe.available?()   #=> true when the breaker is closed
+MyApp.Stripe.blown?()       #=> true when the breaker is open
+MyApp.Stripe.reset()        #=> force the breaker closed
+```
+
+Or with the functional API:
+
+```elixir
+ExternalService.available?(:payments)
+ExternalService.blown?(:payments)
+ExternalService.all_available?([:payments, :inventory])
+ExternalService.reset(:payments)
+```
+
+A few semantics worth knowing:
+
+  * **`available?/1`** is `true` only when the breaker is closed. A service that
+    was never started reports `false` — it is not "ready to use."
+  * **`blown?/1`** is the direct "is it open?" question. A service that was
+    never started is *not* reported as blown (there is no breaker to be open);
+    use `available?/1` when you want "ready to use" semantics.
+  * **`all_available?/1`** is `true` only if *every* listed service is
+    `available?/1` — handy for guarding work that depends on several services.
+  * Availability can change between the check and a subsequent call, so treat
+    these as best-effort signals, not guarantees. They let you bail out early;
+    they do not replace handling a `CircuitBreakerOpen` error from the call
+    itself.
+
+`reset/1` forces the breaker closed immediately, discarding its recorded
+failures. It is mainly useful in tests and in operational tooling ("we fixed the
+upstream, stop failing fast now").
+
+## Fault injection (for testing)
+
+The `:fault_injection` option makes the breaker fail a random fraction of calls,
+which is useful for exercising your own fallback and error-handling paths:
+
+```elixir
+use ExternalService,
+  circuit_breaker: [tolerate: 5, within: 1_000, fault_injection: 0.25]
+```
+
+This is a testing aid — leave it unset in production.
+
+## Choosing thresholds
+
+There is no universally correct setting; it depends on the service's normal
+error rate and how costly a false trip is. Some rules of thumb:
+
+  * Set `:tolerate`/`:within` so the breaker tolerates normal transient noise
+    but trips promptly on a real outage. Counting failures over a window (rather
+    than consecutively) makes it robust to interleaved success and failure.
+  * Set `:reset` to roughly how long you expect a recovering service to need. Too
+    short and you hammer a service that isn't ready; too long and you stay
+    degraded after it has recovered.
+  * Remember the breaker is global to the service. Size it for aggregate traffic,
+    not a single caller.

--- a/guides/circuit-breakers.md
+++ b/guides/circuit-breakers.md
@@ -1,12 +1,12 @@
 # Circuit Breakers
 
-The circuit breaker is what protects your application from a *persistently*
+The circuit breaker is what protects your application from a _persistently_
 failing dependency. Where retries handle the occasional blip, the breaker
 handles the outage: once a service fails too often, the breaker "opens" and
 further calls fail fast — immediately, without touching the struggling service —
 until it has had time to recover.
 
-This is the mechanism described in Michael Nygard's *Release It!* and popularized
+This is the mechanism described in Michael Nygard's _Release It!_ and popularized
 by Martin Fowler. `ExternalService` implements it on top of the Erlang
 [`:fuse`](https://github.com/jlouis/fuse) library, but you never call `:fuse`
 directly — the breaker is managed for you on every call.
@@ -14,7 +14,7 @@ directly — the breaker is managed for you on every call.
 ## Why fail fast?
 
 When a dependency is down and you keep calling it, every caller blocks on
-timeouts, work piles up, and the failure spreads — a *cascading* failure. The
+timeouts, work piles up, and the failure spreads — a _cascading_ failure. The
 breaker short-circuits that: after enough failures it stops you from even
 attempting the call, so callers get an immediate error they can handle (serve
 cached data, degrade gracefully, return 503) instead of hanging.
@@ -37,12 +37,12 @@ use ExternalService,
   ]
 ```
 
-| Option | Default | Meaning |
-| --- | --- | --- |
-| `:tolerate` | `10` | Number of failures tolerated within the `:within` window before the breaker opens. |
-| `:within` | `10_000` | Length of the failure-counting window, in milliseconds. |
-| `:reset` | `60_000` | Milliseconds to wait before the breaker resets (closes) after opening. |
-| `:fault_injection` | — | If set to a rate between `0.0` and `1.0`, randomly fails that fraction of calls (for testing). |
+| Option             | Default  | Meaning                                                                                        |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------- |
+| `:tolerate`        | `10`     | Number of failures tolerated within the `:within` window before the breaker opens.             |
+| `:within`          | `10_000` | Length of the failure-counting window, in milliseconds.                                        |
+| `:reset`           | `60_000` | Milliseconds to wait before the breaker resets (closes) after opening.                         |
+| `:fault_injection` | —        | If set to a rate between `0.0` and `1.0`, randomly fails that fraction of calls (for testing). |
 
 So `tolerate: 5, within: 1_000` means "open the breaker once there are more than
 5 failures inside any 1-second window." After opening, the breaker stays open
@@ -57,13 +57,13 @@ get the defaults above.
 The breaker is "melted" — pushed one step toward opening — on every call attempt
 that fails, where a failure is:
 
-  * the function returns `:retry` or `{:retry, reason}`, or
-  * the function raises an exception.
+- the function returns `:retry` or `{:retry, reason}`, or
+- the function raises an exception.
 
 > #### Melt vs. retry {: .info}
 >
 > A failure melts the breaker **whether or not the call is retried**. The
-> `:retry_on` retry option governs whether a *raised exception* triggers another
+> `:retry_on` retry option governs whether a _raised exception_ triggers another
 > attempt; it does not change what melts the breaker. A raised exception that is
 > not retried still melts the breaker and then propagates to the caller.
 
@@ -75,10 +75,10 @@ successes as far as the breaker is concerned and do not melt it.
 A call made while the breaker is open does not invoke your function at all.
 Instead:
 
-  * `call/3` returns `{:error, %ExternalService.CircuitBreakerOpen{}}`,
-  * `call!/3` raises `ExternalService.CircuitBreakerOpen`, and
-  * an `[:external_service, :circuit_breaker, :blown]` telemetry event is
-    emitted.
+- `call/3` returns `{:error, %ExternalService.CircuitBreakerOpen{}}`,
+- `call!/3` raises `ExternalService.CircuitBreakerOpen`, and
+- an `[:external_service, :circuit_breaker, :blown]` telemetry event is
+  emitted.
 
 See [Error handling](error-handling.md) for how to deal with these.
 
@@ -103,17 +103,17 @@ ExternalService.reset(:payments)
 
 A few semantics worth knowing:
 
-  * **`available?/1`** is `true` only when the breaker is closed. A service that
-    was never started reports `false` — it is not "ready to use."
-  * **`blown?/1`** is the direct "is it open?" question. A service that was
-    never started is *not* reported as blown (there is no breaker to be open);
-    use `available?/1` when you want "ready to use" semantics.
-  * **`all_available?/1`** is `true` only if *every* listed service is
-    `available?/1` — handy for guarding work that depends on several services.
-  * Availability can change between the check and a subsequent call, so treat
-    these as best-effort signals, not guarantees. They let you bail out early;
-    they do not replace handling a `CircuitBreakerOpen` error from the call
-    itself.
+- **`available?/1`** is `true` only when the breaker is closed. A service that
+  was never started reports `false` — it is not "ready to use."
+- **`blown?/1`** is the direct "is it open?" question. A service that was
+  never started is _not_ reported as blown (there is no breaker to be open);
+  use `available?/1` when you want "ready to use" semantics.
+- **`all_available?/1`** is `true` only if _every_ listed service is
+  `available?/1` — handy for guarding work that depends on several services.
+- Availability can change between the check and a subsequent call, so treat
+  these as best-effort signals, not guarantees. They let you bail out early;
+  they do not replace handling a `CircuitBreakerOpen` error from the call
+  itself.
 
 `reset/1` forces the breaker closed immediately, discarding its recorded
 failures. It is mainly useful in tests and in operational tooling ("we fixed the
@@ -136,11 +136,11 @@ This is a testing aid — leave it unset in production.
 There is no universally correct setting; it depends on the service's normal
 error rate and how costly a false trip is. Some rules of thumb:
 
-  * Set `:tolerate`/`:within` so the breaker tolerates normal transient noise
-    but trips promptly on a real outage. Counting failures over a window (rather
-    than consecutively) makes it robust to interleaved success and failure.
-  * Set `:reset` to roughly how long you expect a recovering service to need. Too
-    short and you hammer a service that isn't ready; too long and you stay
-    degraded after it has recovered.
-  * Remember the breaker is global to the service. Size it for aggregate traffic,
-    not a single caller.
+- Set `:tolerate`/`:within` so the breaker tolerates normal transient noise
+  but trips promptly on a real outage. Counting failures over a window (rather
+  than consecutively) makes it robust to interleaved success and failure.
+- Set `:reset` to roughly how long you expect a recovering service to need. Too
+  short and you hammer a service that isn't ready; too long and you stay
+  degraded after it has recovered.
+- Remember the breaker is global to the service. Size it for aggregate traffic,
+  not a single caller.

--- a/guides/error-handling.md
+++ b/guides/error-handling.md
@@ -1,0 +1,119 @@
+# Error Handling
+
+`ExternalService` distinguishes two kinds of failure:
+
+  * **Errors from the service itself** — whatever your wrapped function returns
+    or raises. These pass through untouched; they are yours to handle.
+  * **Errors from `ExternalService`** — retries exhausted, or the circuit
+    breaker open. These are surfaced as structured error types.
+
+Keeping the two straight is the key to clean error handling. This guide covers
+the structured error types and the choice between `call/3` and `call!/3`.
+
+## The structured error types
+
+`ExternalService` errors are built on [Errata](https://hexdocs.pm/errata)
+infrastructure errors. The same struct is *returned* by `call/3` (inside an
+`{:error, struct}` tuple) and *raised* by `call!/3`.
+
+| Error | Returned/raised when | `http_status/1` |
+| --- | --- | --- |
+| `ExternalService.RetriesExhausted` | retries (count or time budget) were exhausted | `503` |
+| `ExternalService.CircuitBreakerOpen` | a call was rejected because the breaker is open | `503` |
+| `ExternalService.ServiceNotStarted` | a call was made to a service never started with `start/2` | `500` |
+
+Each carries a `:context` map that always includes the `:service` it relates to.
+`RetriesExhausted` additionally carries `:context.reason` — the value from the
+function's last `{:retry, reason}` return, or `:reason_unknown` if it returned a
+bare `:retry`.
+
+```elixir
+{:error, %ExternalService.RetriesExhausted{context: %{service: svc, reason: reason}}} ->
+  Logger.error("#{inspect(svc)} exhausted retries: #{inspect(reason)}")
+```
+
+Because they are Errata infrastructure errors, they also come with an
+`http_status/1` and JSON encoding for free — convenient for turning a failure
+into an HTTP response or a structured log entry. `ServiceNotStarted` maps to
+`500` (it signals a configuration/programming mistake, not a transient outage);
+the other two map to `503`.
+
+## `call` — errors as values
+
+`call/3` returns the structured error in an `{:error, struct}` tuple, alongside
+your function's own results. Match on the struct types you care about:
+
+```elixir
+case MyApp.Stripe.charge(params) do
+  {:ok, result} ->
+    {:ok, result}
+
+  {:error, %ExternalService.RetriesExhausted{}} ->
+    {:error, :payment_temporarily_unavailable}
+
+  {:error, %ExternalService.CircuitBreakerOpen{}} ->
+    {:error, :payment_temporarily_unavailable}
+
+  {:error, reason} ->
+    # an error your own function returned, e.g. {:error, :card_declined}
+    {:error, reason}
+end
+```
+
+Notice the last clause: an `{:error, :card_declined}` that your function returned
+is *not* an `ExternalService` error. It flows through `call` unchanged, so you
+handle it like any other domain result.
+
+## `call!` — errors as exceptions
+
+When the only thing you'd do with an `ExternalService` error is bail out, the
+returned-tuple style adds noise: you must distinguish library errors from your
+own results at every call site. `call!/3` raises the structured errors instead,
+letting your happy path stay clean and your failure handling live in one
+`rescue`:
+
+```elixir
+def create(conn, %{"message" => message}) do
+  result = MyApp.PubSub.publish!(message, @topic)
+  send_resp(conn, 201, encode(result))
+rescue
+  e in [ExternalService.RetriesExhausted, ExternalService.CircuitBreakerOpen] ->
+    Logger.error(Exception.format(:error, e))
+    send_resp(conn, 503, "")
+end
+```
+
+`call!/3` only *raises* the `ExternalService` errors; values your function
+returns are still returned normally. And because every error knows its own
+`http_status/1`, you can collapse the handling further:
+
+```elixir
+rescue
+  e in [ExternalService.RetriesExhausted, ExternalService.CircuitBreakerOpen,
+        ExternalService.ServiceNotStarted] ->
+    send_resp(conn, ExternalService.RetriesExhausted.http_status(e), "")
+end
+```
+
+## Which should I use?
+
+  * Use **`call/3`** when an `ExternalService` failure is a normal branch in your
+    logic — you want to fall back to cached data, return a specific domain error,
+    or otherwise react in line.
+  * Use **`call!/3`** when an `ExternalService` failure should abort the current
+    unit of work and be handled uniformly higher up (a Phoenix action, an Oban
+    job, a task). It keeps the happy path readable.
+
+Both apply identical retry and circuit-breaker behavior; they differ only in how
+the *library's* failures are delivered.
+
+## A note on exceptions from your function
+
+Remember that, by default, exceptions raised by your wrapped function are **not
+retried** — they propagate to the caller (out of both `call/3` and `call!/3`).
+They are also not converted into `ExternalService` error types; a raised
+`MyApp.HTTPError` comes out of `call` as a raised `MyApp.HTTPError`. If you want
+such an exception retried, add its module to the `:retry_on` retry option (see
+[Retries](retries.md)). If you want it returned rather than raised, catch it
+inside your function and return an `{:error, reason}` (or `{:retry, reason}`)
+value.

--- a/guides/error-handling.md
+++ b/guides/error-handling.md
@@ -2,10 +2,10 @@
 
 `ExternalService` distinguishes two kinds of failure:
 
-  * **Errors from the service itself** — whatever your wrapped function returns
-    or raises. These pass through untouched; they are yours to handle.
-  * **Errors from `ExternalService`** — retries exhausted, or the circuit
-    breaker open. These are surfaced as structured error types.
+- **Errors from the service itself** — whatever your wrapped function returns
+  or raises. These pass through untouched; they are yours to handle.
+- **Errors from `ExternalService`** — retries exhausted, or the circuit
+  breaker open. These are surfaced as structured error types.
 
 Keeping the two straight is the key to clean error handling. This guide covers
 the structured error types and the choice between `call/3` and `call!/3`.
@@ -13,14 +13,14 @@ the structured error types and the choice between `call/3` and `call!/3`.
 ## The structured error types
 
 `ExternalService` errors are built on [Errata](https://hexdocs.pm/errata)
-infrastructure errors. The same struct is *returned* by `call/3` (inside an
-`{:error, struct}` tuple) and *raised* by `call!/3`.
+infrastructure errors. The same struct is _returned_ by `call/3` (inside an
+`{:error, struct}` tuple) and _raised_ by `call!/3`.
 
-| Error | Returned/raised when | `http_status/1` |
-| --- | --- | --- |
-| `ExternalService.RetriesExhausted` | retries (count or time budget) were exhausted | `503` |
-| `ExternalService.CircuitBreakerOpen` | a call was rejected because the breaker is open | `503` |
-| `ExternalService.ServiceNotStarted` | a call was made to a service never started with `start/2` | `500` |
+| Error                                | Returned/raised when                                      | `http_status/1` |
+| ------------------------------------ | --------------------------------------------------------- | --------------- |
+| `ExternalService.RetriesExhausted`   | retries (count or time budget) were exhausted             | `503`           |
+| `ExternalService.CircuitBreakerOpen` | a call was rejected because the breaker is open           | `503`           |
+| `ExternalService.ServiceNotStarted`  | a call was made to a service never started with `start/2` | `500`           |
 
 Each carries a `:context` map that always includes the `:service` it relates to.
 `RetriesExhausted` additionally carries `:context.reason` — the value from the
@@ -61,7 +61,7 @@ end
 ```
 
 Notice the last clause: an `{:error, :card_declined}` that your function returned
-is *not* an `ExternalService` error. It flows through `call` unchanged, so you
+is _not_ an `ExternalService` error. It flows through `call` unchanged, so you
 handle it like any other domain result.
 
 ## `call!` — errors as exceptions
@@ -83,7 +83,7 @@ rescue
 end
 ```
 
-`call!/3` only *raises* the `ExternalService` errors; values your function
+`call!/3` only _raises_ the `ExternalService` errors; values your function
 returns are still returned normally. And because every error knows its own
 `http_status/1`, you can collapse the handling further:
 
@@ -97,15 +97,15 @@ end
 
 ## Which should I use?
 
-  * Use **`call/3`** when an `ExternalService` failure is a normal branch in your
-    logic — you want to fall back to cached data, return a specific domain error,
-    or otherwise react in line.
-  * Use **`call!/3`** when an `ExternalService` failure should abort the current
-    unit of work and be handled uniformly higher up (a Phoenix action, an Oban
-    job, a task). It keeps the happy path readable.
+- Use **`call/3`** when an `ExternalService` failure is a normal branch in your
+  logic — you want to fall back to cached data, return a specific domain error,
+  or otherwise react in line.
+- Use **`call!/3`** when an `ExternalService` failure should abort the current
+  unit of work and be handled uniformly higher up (a Phoenix action, an Oban
+  job, a task). It keeps the happy path readable.
 
 Both apply identical retry and circuit-breaker behavior; they differ only in how
-the *library's* failures are delivered.
+the _library's_ failures are delivered.
 
 ## A note on exceptions from your function
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -26,14 +26,13 @@ Calling an external service is risky: the network hiccups, the service is
 briefly overloaded, or it goes down entirely. `ExternalService` wraps those
 calls with two complementary safety mechanisms:
 
-  * **Retries** smooth over *transient* failures by trying a failed request
-    again, with configurable backoff.
-  * A **circuit breaker** protects you from a service that is *persistently*
-    failing: once failures cross a threshold the breaker "opens" and further
-    calls fail fast instead of piling up against a service that is already down.
-
-Optionally, a **rate limiter** keeps you under the call quota the external
-service imposes.
+- **Retries** smooth over _transient_ failures by trying a failed request
+  again, with configurable backoff.
+- A **circuit breaker** protects you from a service that is _persistently_
+  failing: once failures cross a threshold the breaker "opens" and further
+  calls fail fast instead of piling up against a service that is already down.
+- Optionally, a **rate limiter** keeps you under the call quota the external
+  service imposes.
 
 You wrap your call to the external service in a function, hand that function to
 `ExternalService`, and it applies all of the above on every call.
@@ -64,12 +63,12 @@ end
 
 A few things to notice:
 
-  * The module configures its own circuit breaker and retry policy. No fuse
-    names to juggle at the call site.
-  * `charge/1` wraps the real Stripe call in a zero-argument function and passes
-    it to the generated `call/1`.
-  * The function returns `:retry` (or `{:retry, reason}`) to ask for another
-    attempt; any other value is treated as success and returned as-is.
+- The module configures its own circuit breaker and retry policy. No fuse
+  names to juggle at the call site.
+- `charge/1` wraps the real Stripe call in a zero-argument function and passes
+  it to the generated `call/1`.
+- The function returns `:retry` (or `{:retry, reason}`) to ask for another
+  attempt; any other value is treated as success and returned as-is.
 
 ## Start it under your supervisor
 
@@ -101,13 +100,13 @@ and the retry, circuit-breaker, and rate-limit logic is applied automatically.
 Inside the function you pass to `call/1`, you decide what counts as a retriable
 failure. There are two ways to ask for a retry:
 
-  1. return the atom `:retry`, or
-  2. return a tuple `{:retry, reason}`, where `reason` is any term (handy for
-     logging and telemetry).
+1. return the atom `:retry`, or
+2. return a tuple `{:retry, reason}`, where `reason` is any term (handy for
+   logging and telemetry).
 
 Any other return value is considered a success and is returned to the caller
 untouched — including the function's own `{:error, reason}` values. This is the
-key distinction: an `{:error, ...}` you return is *your* error and passes
+key distinction: an `{:error, ...}` you return is _your_ error and passes
 through; only `:retry`/`{:retry, reason}` drive the retry machinery.
 
 ```elixir
@@ -117,7 +116,7 @@ def fetch(id) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:ok, %{status: status}} when status in 500..599 -> {:retry, status}
       {:ok, %{status: 404}} -> {:error, :not_found}   # not retried — your error
-      {:error, %HTTPError{}} = err -> err              # not retried — your error
+      {:error, %HTTPError{}} = err -> err             # not retried — your error
     end
   end
 end
@@ -158,14 +157,14 @@ full picture.
 
 ## Where to go next
 
-  * **[The module front door](the-front-door.md)** — everything `use
-    ExternalService` generates, plus supervision and per-environment overrides.
-  * **[Circuit breakers](circuit-breakers.md)** — how the breaker trips and
-    resets, and how to introspect it.
-  * **[Retries](retries.md)** — backoff strategies, jitter, attempt and time
-    budgets, and retrying on exceptions.
-  * **[Rate limiting](rate-limiting.md)** — staying under a service's quota.
-  * **[Error handling](error-handling.md)** — `call` vs `call!` and the
-    structured error types.
-  * **[Telemetry](telemetry.md)** — observing calls, retries, and breaker trips.
-  * **[Migrating to 2.0](migrating-to-2.0.md)** — upgrading from 1.x.
+- **[The module front door](the-front-door.md)** — everything `use
+ExternalService` generates, plus supervision and per-environment overrides.
+- **[Circuit breakers](circuit-breakers.md)** — how the breaker trips and
+  resets, and how to introspect it.
+- **[Retries](retries.md)** — backoff strategies, jitter, attempt and time
+  budgets, and retrying on exceptions.
+- **[Rate limiting](rate-limiting.md)** — staying under a service's quota.
+- **[Error handling](error-handling.md)** — `call` vs `call!` and the
+  structured error types.
+- **[Telemetry](telemetry.md)** — observing calls, retries, and breaker trips.
+- **[Migrating to 2.0](migrating-to-2.0.md)** — upgrading from 1.x.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,0 +1,171 @@
+# Getting Started
+
+This guide walks you through adding `ExternalService` to a project and making
+your first reliable call to an external API — with retries, a circuit breaker,
+and (optionally) rate limiting all working for you out of the box.
+
+For full reference material, see the `ExternalService` module docs.
+
+## Installation
+
+Add `external_service` to your dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:external_service, "~> 2.0"}
+  ]
+end
+```
+
+Then run `mix deps.get`.
+
+## The big idea
+
+Calling an external service is risky: the network hiccups, the service is
+briefly overloaded, or it goes down entirely. `ExternalService` wraps those
+calls with two complementary safety mechanisms:
+
+  * **Retries** smooth over *transient* failures by trying a failed request
+    again, with configurable backoff.
+  * A **circuit breaker** protects you from a service that is *persistently*
+    failing: once failures cross a threshold the breaker "opens" and further
+    calls fail fast instead of piling up against a service that is already down.
+
+Optionally, a **rate limiter** keeps you under the call quota the external
+service imposes.
+
+You wrap your call to the external service in a function, hand that function to
+`ExternalService`, and it applies all of the above on every call.
+
+## Your first service
+
+The recommended way to use the library is the declarative **module front door**,
+`use ExternalService`. Define a module for the service you depend on and
+configure its behavior in one place:
+
+```elixir
+defmodule MyApp.Stripe do
+  use ExternalService,
+    circuit_breaker: [tolerate: 5, within: :timer.seconds(1), reset: :timer.seconds(5)],
+    retry: [max_attempts: 5, backoff: :exponential, jitter: true]
+
+  def charge(params) do
+    call fn ->
+      case Stripe.charge(params) do
+        {:ok, result} -> {:ok, result}
+        {:error, %{status: status}} when status in 500..599 -> :retry
+        other -> other
+      end
+    end
+  end
+end
+```
+
+A few things to notice:
+
+  * The module configures its own circuit breaker and retry policy. No fuse
+    names to juggle at the call site.
+  * `charge/1` wraps the real Stripe call in a zero-argument function and passes
+    it to the generated `call/1`.
+  * The function returns `:retry` (or `{:retry, reason}`) to ask for another
+    attempt; any other value is treated as success and returned as-is.
+
+## Start it under your supervisor
+
+A service must be started before it can be called — starting installs its
+circuit breaker (and rate limiter, if configured). Add the module to your
+supervision tree:
+
+```elixir
+def start(_type, _args) do
+  children = [
+    MyApp.Stripe
+    # ... the rest of your children
+  ]
+
+  Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)
+end
+```
+
+That's it. Anywhere in your application you can now call:
+
+```elixir
+MyApp.Stripe.charge(%{amount: 1000, currency: "usd", source: token})
+```
+
+and the retry, circuit-breaker, and rate-limit logic is applied automatically.
+
+## Triggering a retry
+
+Inside the function you pass to `call/1`, you decide what counts as a retriable
+failure. There are two ways to ask for a retry:
+
+  1. return the atom `:retry`, or
+  2. return a tuple `{:retry, reason}`, where `reason` is any term (handy for
+     logging and telemetry).
+
+Any other return value is considered a success and is returned to the caller
+untouched — including the function's own `{:error, reason}` values. This is the
+key distinction: an `{:error, ...}` you return is *your* error and passes
+through; only `:retry`/`{:retry, reason}` drive the retry machinery.
+
+```elixir
+def fetch(id) do
+  call fn ->
+    case HTTP.get("/widgets/#{id}") do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, %{status: status}} when status in 500..599 -> {:retry, status}
+      {:ok, %{status: 404}} -> {:error, :not_found}   # not retried — your error
+      {:error, %HTTPError{}} = err -> err              # not retried — your error
+    end
+  end
+end
+```
+
+By default, **raised exceptions are not retried** — they propagate to the
+caller. If you want an exception type to trigger a retry, list it in the
+`:retry_on` retry option. See the [Retries](retries.md) guide for the full set
+of retry knobs.
+
+## Handling failures
+
+When retries are exhausted or the circuit breaker is open, `call/1` returns a
+structured error:
+
+```elixir
+case MyApp.Stripe.charge(params) do
+  {:ok, result} ->
+    handle_success(result)
+
+  {:error, %ExternalService.RetriesExhausted{}} ->
+    # transient failure outlasted our retry budget
+    {:error, :payment_unavailable}
+
+  {:error, %ExternalService.CircuitBreakerOpen{}} ->
+    # the breaker is open; fail fast
+    {:error, :payment_unavailable}
+
+  {:error, reason} ->
+    # an error your own function returned
+    {:error, reason}
+end
+```
+
+If you'd rather these failures raise instead of being returned, use the
+generated `call!/1`. See the [Error handling](error-handling.md) guide for the
+full picture.
+
+## Where to go next
+
+  * **[The module front door](the-front-door.md)** — everything `use
+    ExternalService` generates, plus supervision and per-environment overrides.
+  * **[Circuit breakers](circuit-breakers.md)** — how the breaker trips and
+    resets, and how to introspect it.
+  * **[Retries](retries.md)** — backoff strategies, jitter, attempt and time
+    budgets, and retrying on exceptions.
+  * **[Rate limiting](rate-limiting.md)** — staying under a service's quota.
+  * **[Error handling](error-handling.md)** — `call` vs `call!` and the
+    structured error types.
+  * **[Telemetry](telemetry.md)** — observing calls, retries, and breaker trips.
+  * **[Migrating to 2.0](migrating-to-2.0.md)** — upgrading from 1.x.

--- a/guides/migrating-to-2.0.md
+++ b/guides/migrating-to-2.0.md
@@ -1,0 +1,263 @@
+# Migrating to 2.0
+
+ExternalService 2.0 is a deliberate, breaking modernization of the library. It
+sheds the leaked "fuse" terminology, validates and documents every option,
+adds telemetry and introspection, and replaces ad-hoc error tuples with
+structured error types. This guide is the mechanical checklist for upgrading a
+1.x codebase.
+
+The changes are real but the upgrade is mostly find-and-replace. Work through the
+sections below in order; each shows the 1.x form and its 2.0 replacement.
+
+> A complete, categorized list of changes is in the
+> [CHANGELOG](changelog.html). This guide focuses on *what you have to do* to
+> upgrade.
+
+## At a glance
+
+| Area | 1.x | 2.0 |
+| --- | --- | --- |
+| Minimum Elixir | < 1.15 | `~> 1.15` |
+| Circuit breaker config | `fuse_strategy: {:standard, max, win}`, `fuse_refresh: ms` | `circuit_breaker: [tolerate:, within:, reset:]` |
+| Rate limit config | `rate_limit: {limit, win}` | `rate_limit: [limit:, per:]` |
+| Service identifier term | `fuse_name` | `service` |
+| Reset a breaker | `reset_fuse/1` | `reset/1` |
+| Retry backoff | `{:exponential, d}` / `{:linear, d, f}` | `backoff: :exponential\|:linear` + `base:`/`factor:` |
+| Retry on exceptions | `rescue_only: [...]` (retried `RuntimeError` by default) | `retry_on: [...]`, default `[]` |
+| Jitter | `randomize:` | `jitter:` |
+| Module gateway | `use ExternalService.Gateway` + `external_call/*` | `use ExternalService` + `call/*` |
+| Library errors (returned) | nested tuples | structured `Errata` structs |
+| Library errors (raised) | `*Error` modules | new structured modules |
+
+## 1. Bump the minimum Elixir version
+
+2.0 requires Elixir `~> 1.15`. Make sure your project (and CI matrix) is on 1.15
+or later before upgrading.
+
+## 2. Update circuit breaker and rate limit configuration
+
+The `fuse_*` options and tuple-style rate limit are gone, replaced by validated
+keyword lists. The option names now describe what they do rather than leaking the
+underlying `:fuse` library.
+
+```elixir
+# Before (1.x)
+ExternalService.start(MyService,
+  fuse_strategy: {:standard, 5, 1_000},
+  fuse_refresh: 5_000,
+  rate_limit: {100, 1_000}
+)
+
+# After (2.0)
+ExternalService.start(MyService,
+  circuit_breaker: [tolerate: 5, within: 1_000, reset: 5_000],
+  rate_limit: [limit: 100, per: 1_000]
+)
+```
+
+The mapping is direct:
+
+  * `fuse_strategy: {:standard, max, window}` → `circuit_breaker: [tolerate: max, within: window]`
+  * `fuse_refresh: ms` → `circuit_breaker: [reset: ms]`
+  * `rate_limit: {limit, window}` → `rate_limit: [limit: limit, per: window]`
+
+For the `{:fault_injection, rate, max, window}` strategy, use
+`circuit_breaker: [fault_injection: rate, tolerate: max, within: window]`.
+
+Options are now validated by [NimbleOptions](https://hexdocs.pm/nimble_options),
+so a typo or wrong type raises a clear error at `start` time instead of silently
+misconfiguring the service. (In fact, in 1.x a mismatched gateway `fuse:` option
+was silently dropped — that class of bug is now impossible.)
+
+## 3. Rename `reset_fuse` to `reset`
+
+```elixir
+# Before
+ExternalService.reset_fuse(MyService)
+
+# After
+ExternalService.reset(MyService)
+```
+
+(On modules using the deprecated gateway, `reset_fuse/0` still works as an
+alias — see section 7.)
+
+## 4. Reshape your retry options
+
+`ExternalService.RetryOptions` changed shape. Backoff is now a plain atom plus
+separate numeric fields, `randomize` became `jitter`, and `rescue_only` became
+`retry_on`.
+
+```elixir
+# Before (1.x)
+%ExternalService.RetryOptions{
+  backoff: {:exponential, 100},
+  randomize: true,
+  rescue_only: [RuntimeError]
+}
+
+# After (2.0)
+%ExternalService.RetryOptions{
+  backoff: :exponential,
+  base: 100,
+  jitter: true,
+  retry_on: [RuntimeError]
+}
+```
+
+Mapping:
+
+  * `backoff: {:exponential, delay}` → `backoff: :exponential, base: delay`
+  * `backoff: {:linear, delay, factor}` → `backoff: :linear, base: delay, factor: factor`
+  * `randomize: true` → `jitter: true` (a float still means that proportion)
+  * `rescue_only: mods` → `retry_on: mods`
+
+You can also now pass retry options as a plain keyword list to `call/3` /
+`call!/3` and to the `:retry` option, not only as a struct.
+
+### ⚠️ Behavior change: exceptions are no longer retried by default
+
+This is the one change that can alter runtime behavior rather than just syntax.
+In 1.x, `rescue_only` defaulted to `[RuntimeError]`, so any raised `RuntimeError`
+was retried automatically. In 2.0, **`retry_on` defaults to `[]`** — raised
+exceptions are *not* retried unless you opt in
+([issue #7](https://github.com/jvoegele/external_service/issues/7)).
+
+If you were relying on exceptions being retried, restore it explicitly:
+
+```elixir
+retry: [retry_on: [RuntimeError]]
+```
+
+But prefer driving retries with `:retry` / `{:retry, reason}` return values where
+you can — it is more explicit and avoids retrying an exception that actually
+signals a bug. See [Retries](retries.md).
+
+## 5. Update error handling
+
+This is the largest source-level change. The library no longer returns nested
+error tuples or raises the old `*Error` modules. It returns (and raises)
+structured [Errata](https://hexdocs.pm/errata) error structs. The *same* struct
+is returned by `call/3` and raised by `call!/3`.
+
+### Returned errors (`call/3`)
+
+| Before (1.x) | After (2.0) |
+| --- | --- |
+| `{:error, {:retries_exhausted, reason}}` | `{:error, %ExternalService.RetriesExhausted{context: %{service: name, reason: reason}}}` |
+| `{:error, {:fuse_blown, name}}` | `{:error, %ExternalService.CircuitBreakerOpen{context: %{service: name}}}` |
+| `{:error, {:fuse_not_found, name}}` | `{:error, %ExternalService.ServiceNotStarted{context: %{service: name}}}` |
+
+```elixir
+# Before (1.x)
+case ExternalService.call(MyService, fun) do
+  {:error, {:retries_exhausted, reason}} -> handle_exhausted(reason)
+  {:error, {:fuse_blown, _name}}         -> handle_blown()
+  result                                 -> result
+end
+
+# After (2.0)
+case ExternalService.call(MyService, fun) do
+  {:error, %ExternalService.RetriesExhausted{context: %{reason: reason}}} -> handle_exhausted(reason)
+  {:error, %ExternalService.CircuitBreakerOpen{}}                         -> handle_blown()
+  result                                                                  -> result
+end
+```
+
+Note the retry `reason` now lives in `context.reason`.
+
+### Raised errors (`call!/3`)
+
+| Before (1.x) | After (2.0) |
+| --- | --- |
+| `ExternalService.RetriesExhaustedError` | `ExternalService.RetriesExhausted` |
+| `ExternalService.FuseBlownError` | `ExternalService.CircuitBreakerOpen` |
+| `ExternalService.FuseNotFoundError` | `ExternalService.ServiceNotStarted` |
+
+```elixir
+# Before (1.x)
+rescue
+  e in [ExternalService.RetriesExhaustedError, ExternalService.FuseBlownError] -> ...
+
+# After (2.0)
+rescue
+  e in [ExternalService.RetriesExhausted, ExternalService.CircuitBreakerOpen] -> ...
+```
+
+The old `*Error` modules have been removed entirely. As a bonus, the new structs
+are Errata infrastructure errors, so they carry an `http_status/1` and JSON
+encoding — see [Error handling](error-handling.md).
+
+Results your own function returns (including its own `{:error, reason}` values)
+are **unchanged** — only the library's own error representations moved.
+
+## 6. Adopt the module front door (recommended)
+
+The blessed way to use 2.0 is `use ExternalService`, which replaces both manual
+`start/2` + `call/3` wiring and the old `ExternalService.Gateway`. You configure
+the service declaratively and start it under your supervisor:
+
+```elixir
+defmodule MyApp.Stripe do
+  use ExternalService,
+    circuit_breaker: [tolerate: 5, within: :timer.seconds(1), reset: :timer.seconds(5)],
+    rate_limit: [limit: 100, per: :timer.seconds(1)],
+    retry: [max_attempts: 5, backoff: :exponential, jitter: true]
+
+  def charge(params), do: call(fn -> Stripe.charge(params) end)
+end
+
+# In your supervision tree:
+children = [MyApp.Stripe]
+```
+
+This isn't required to upgrade — the functional `start/2` + `call/3` API is fully
+supported — but it is the most polished way to use the library. See
+[The module front door](the-front-door.md).
+
+## 7. Migrate off `ExternalService.Gateway`
+
+`use ExternalService.Gateway` still compiles but is **deprecated** and emits a
+warning. It now delegates to `use ExternalService`, keeping the
+`external_call/*` and `reset_fuse/0` names as aliases — but it uses the new
+option shape, so the old `fuse: [strategy:, refresh:]` options are gone.
+
+```elixir
+# Before (1.x)
+defmodule MyApp.PubSub do
+  use ExternalService.Gateway,
+    fuse: [name: MyApp.PubSub, strategy: {:standard, 5, 1_000}, refresh: 5_000],
+    rate_limit: {100, 1_000},
+    retry: [backoff: {:linear, 100, 1}, expiry: 5_000]
+
+  def publish(msg), do: external_call(fn -> do_publish(msg) end)
+end
+
+# After (2.0)
+defmodule MyApp.PubSub do
+  use ExternalService,
+    name: MyApp.PubSub,
+    circuit_breaker: [tolerate: 5, within: 1_000, reset: 5_000],
+    rate_limit: [limit: 100, per: 1_000],
+    retry: [backoff: :linear, base: 100, expiry: 5_000]
+
+  def publish(msg), do: call(fn -> do_publish(msg) end)
+end
+```
+
+Renames at the call site: `external_call` → `call`, `external_call!` → `call!`,
+`external_call_async` → `call_async`, `external_call_async_stream` →
+`call_async_stream`, `reset_fuse` → `reset`.
+
+## Upgrade checklist
+
+- [ ] Elixir `~> 1.15` everywhere (deps and CI).
+- [ ] `fuse_strategy:`/`fuse_refresh:` → `circuit_breaker: [tolerate:, within:, reset:]`.
+- [ ] `rate_limit: {l, w}` → `rate_limit: [limit: l, per: w]`.
+- [ ] `reset_fuse/1` → `reset/1`.
+- [ ] `RetryOptions`: tuple backoff → atom `backoff:` + `base:`/`factor:`; `randomize:` → `jitter:`; `rescue_only:` → `retry_on:`.
+- [ ] Re-add `retry_on: [RuntimeError]` only where you actually want exceptions retried.
+- [ ] Replace error tuples with the structured `RetriesExhausted` / `CircuitBreakerOpen` / `ServiceNotStarted` structs.
+- [ ] Replace the old `*Error` modules in `rescue` clauses.
+- [ ] (Recommended) Move `use ExternalService.Gateway` modules to `use ExternalService`.
+- [ ] Run your test suite; let NimbleOptions validation surface any missed config.

--- a/guides/migrating-to-2.0.md
+++ b/guides/migrating-to-2.0.md
@@ -10,24 +10,24 @@ The changes are real but the upgrade is mostly find-and-replace. Work through th
 sections below in order; each shows the 1.x form and its 2.0 replacement.
 
 > A complete, categorized list of changes is in the
-> [CHANGELOG](changelog.html). This guide focuses on *what you have to do* to
+> [CHANGELOG](changelog.html). This guide focuses on _what you have to do_ to
 > upgrade.
 
 ## At a glance
 
-| Area | 1.x | 2.0 |
-| --- | --- | --- |
-| Minimum Elixir | < 1.15 | `~> 1.15` |
-| Circuit breaker config | `fuse_strategy: {:standard, max, win}`, `fuse_refresh: ms` | `circuit_breaker: [tolerate:, within:, reset:]` |
-| Rate limit config | `rate_limit: {limit, win}` | `rate_limit: [limit:, per:]` |
-| Service identifier term | `fuse_name` | `service` |
-| Reset a breaker | `reset_fuse/1` | `reset/1` |
-| Retry backoff | `{:exponential, d}` / `{:linear, d, f}` | `backoff: :exponential\|:linear` + `base:`/`factor:` |
-| Retry on exceptions | `rescue_only: [...]` (retried `RuntimeError` by default) | `retry_on: [...]`, default `[]` |
-| Jitter | `randomize:` | `jitter:` |
-| Module gateway | `use ExternalService.Gateway` + `external_call/*` | `use ExternalService` + `call/*` |
-| Library errors (returned) | nested tuples | structured `Errata` structs |
-| Library errors (raised) | `*Error` modules | new structured modules |
+| Area                      | 1.x                                                        | 2.0                                                  |
+| ------------------------- | ---------------------------------------------------------- | ---------------------------------------------------- |
+| Minimum Elixir            | < 1.15                                                     | `~> 1.15`                                            |
+| Circuit breaker config    | `fuse_strategy: {:standard, max, win}`, `fuse_refresh: ms` | `circuit_breaker: [tolerate:, within:, reset:]`      |
+| Rate limit config         | `rate_limit: {limit, win}`                                 | `rate_limit: [limit:, per:]`                         |
+| Service identifier term   | `fuse_name`                                                | `service`                                            |
+| Reset a breaker           | `reset_fuse/1`                                             | `reset/1`                                            |
+| Retry backoff             | `{:exponential, d}` / `{:linear, d, f}`                    | `backoff: :exponential\|:linear` + `base:`/`factor:` |
+| Retry on exceptions       | `rescue_only: [...]` (retried `RuntimeError` by default)   | `retry_on: [...]`, default `[]`                      |
+| Jitter                    | `randomize:`                                               | `jitter:`                                            |
+| Module gateway            | `use ExternalService.Gateway` + `external_call/*`          | `use ExternalService` + `call/*`                     |
+| Library errors (returned) | nested tuples                                              | structured `Errata` structs                          |
+| Library errors (raised)   | `*Error` modules                                           | new structured modules                               |
 
 ## 1. Bump the minimum Elixir version
 
@@ -57,9 +57,9 @@ ExternalService.start(MyService,
 
 The mapping is direct:
 
-  * `fuse_strategy: {:standard, max, window}` → `circuit_breaker: [tolerate: max, within: window]`
-  * `fuse_refresh: ms` → `circuit_breaker: [reset: ms]`
-  * `rate_limit: {limit, window}` → `rate_limit: [limit: limit, per: window]`
+- `fuse_strategy: {:standard, max, window}` → `circuit_breaker: [tolerate: max, within: window]`
+- `fuse_refresh: ms` → `circuit_breaker: [reset: ms]`
+- `rate_limit: {limit, window}` → `rate_limit: [limit: limit, per: window]`
 
 For the `{:fault_injection, rate, max, window}` strategy, use
 `circuit_breaker: [fault_injection: rate, tolerate: max, within: window]`.
@@ -107,10 +107,10 @@ separate numeric fields, `randomize` became `jitter`, and `rescue_only` became
 
 Mapping:
 
-  * `backoff: {:exponential, delay}` → `backoff: :exponential, base: delay`
-  * `backoff: {:linear, delay, factor}` → `backoff: :linear, base: delay, factor: factor`
-  * `randomize: true` → `jitter: true` (a float still means that proportion)
-  * `rescue_only: mods` → `retry_on: mods`
+- `backoff: {:exponential, delay}` → `backoff: :exponential, base: delay`
+- `backoff: {:linear, delay, factor}` → `backoff: :linear, base: delay, factor: factor`
+- `randomize: true` → `jitter: true` (a float still means that proportion)
+- `rescue_only: mods` → `retry_on: mods`
 
 You can also now pass retry options as a plain keyword list to `call/3` /
 `call!/3` and to the `:retry` option, not only as a struct.
@@ -120,7 +120,7 @@ You can also now pass retry options as a plain keyword list to `call/3` /
 This is the one change that can alter runtime behavior rather than just syntax.
 In 1.x, `rescue_only` defaulted to `[RuntimeError]`, so any raised `RuntimeError`
 was retried automatically. In 2.0, **`retry_on` defaults to `[]`** — raised
-exceptions are *not* retried unless you opt in
+exceptions are _not_ retried unless you opt in
 ([issue #7](https://github.com/jvoegele/external_service/issues/7)).
 
 If you were relying on exceptions being retried, restore it explicitly:
@@ -137,16 +137,16 @@ signals a bug. See [Retries](retries.md).
 
 This is the largest source-level change. The library no longer returns nested
 error tuples or raises the old `*Error` modules. It returns (and raises)
-structured [Errata](https://hexdocs.pm/errata) error structs. The *same* struct
+structured [Errata](https://hexdocs.pm/errata) error structs. The _same_ struct
 is returned by `call/3` and raised by `call!/3`.
 
 ### Returned errors (`call/3`)
 
-| Before (1.x) | After (2.0) |
-| --- | --- |
+| Before (1.x)                             | After (2.0)                                                                              |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------- |
 | `{:error, {:retries_exhausted, reason}}` | `{:error, %ExternalService.RetriesExhausted{context: %{service: name, reason: reason}}}` |
-| `{:error, {:fuse_blown, name}}` | `{:error, %ExternalService.CircuitBreakerOpen{context: %{service: name}}}` |
-| `{:error, {:fuse_not_found, name}}` | `{:error, %ExternalService.ServiceNotStarted{context: %{service: name}}}` |
+| `{:error, {:fuse_blown, name}}`          | `{:error, %ExternalService.CircuitBreakerOpen{context: %{service: name}}}`               |
+| `{:error, {:fuse_not_found, name}}`      | `{:error, %ExternalService.ServiceNotStarted{context: %{service: name}}}`                |
 
 ```elixir
 # Before (1.x)
@@ -168,11 +168,11 @@ Note the retry `reason` now lives in `context.reason`.
 
 ### Raised errors (`call!/3`)
 
-| Before (1.x) | After (2.0) |
-| --- | --- |
-| `ExternalService.RetriesExhaustedError` | `ExternalService.RetriesExhausted` |
-| `ExternalService.FuseBlownError` | `ExternalService.CircuitBreakerOpen` |
-| `ExternalService.FuseNotFoundError` | `ExternalService.ServiceNotStarted` |
+| Before (1.x)                            | After (2.0)                          |
+| --------------------------------------- | ------------------------------------ |
+| `ExternalService.RetriesExhaustedError` | `ExternalService.RetriesExhausted`   |
+| `ExternalService.FuseBlownError`        | `ExternalService.CircuitBreakerOpen` |
+| `ExternalService.FuseNotFoundError`     | `ExternalService.ServiceNotStarted`  |
 
 ```elixir
 # Before (1.x)

--- a/guides/rate-limiting.md
+++ b/guides/rate-limiting.md
@@ -1,7 +1,7 @@
 # Rate Limiting
 
-Many external services impose a quota: *no more than N requests per time
-window.* Exceed it and you get throttled (or billed, or blocked).
+Many external services impose a quota: _no more than N requests per time
+window._ Exceed it and you get throttled (or billed, or blocked).
 `ExternalService` can keep you under that quota automatically, across your entire
 application, using the [ex_rated](https://hex.pm/packages/ex_rated) library.
 
@@ -21,10 +21,10 @@ use ExternalService,
   ]
 ```
 
-| Option | Required | Meaning |
-| --- | --- | --- |
-| `:limit` | yes | Maximum number of calls allowed within each `:per` window. |
-| `:per` | yes | Length of the rate-limiting window, in milliseconds. |
+| Option   | Required | Meaning                                                    |
+| -------- | -------- | ---------------------------------------------------------- |
+| `:limit` | yes      | Maximum number of calls allowed within each `:per` window. |
+| `:per`   | yes      | Length of the rate-limiting window, in milliseconds.       |
 
 Both keys are required when `:rate_limit` is present.
 
@@ -32,7 +32,7 @@ Both keys are required when `:rate_limit` is present.
 
 The limit is tracked per service and shared across every caller in your
 application — every process that calls the service draws from the same bucket. So
-the example above guarantees no more than 100 calls per second *in total*, no
+the example above guarantees no more than 100 calls per second _in total_, no
 matter how many processes are making them.
 
 When a call would exceed the limit, `ExternalService` does not fail it. Instead
@@ -51,11 +51,11 @@ end)
 
 The sleeping happens in whichever process is making the call:
 
-  * With `call/1` (synchronous), the **calling process** sleeps. Your code blocks
-    until the call is allowed.
-  * With `call_async/1` and `call_async_stream/2`, the **background task(s)**
-    sleep, not your calling process. This is often what you want for bulk work:
-    kick off the stream and let the workers pace themselves.
+- With `call/1` (synchronous), the **calling process** sleeps. Your code blocks
+  until the call is allowed.
+- With `call_async/1` and `call_async_stream/2`, the **background task(s)**
+  sleep, not your calling process. This is often what you want for bulk work:
+  kick off the stream and let the workers pace themselves.
 
 ```elixir
 # Bulk import that respects the rate limit without blocking the caller:

--- a/guides/rate-limiting.md
+++ b/guides/rate-limiting.md
@@ -1,0 +1,94 @@
+# Rate Limiting
+
+Many external services impose a quota: *no more than N requests per time
+window.* Exceed it and you get throttled (or billed, or blocked).
+`ExternalService` can keep you under that quota automatically, across your entire
+application, using the [ex_rated](https://hex.pm/packages/ex_rated) library.
+
+Rate limiting is **opt-in**: omit the `:rate_limit` option and no limiting is
+applied.
+
+## Configuration
+
+Add a `:rate_limit` option with a `:limit` and a `:per` window (in
+milliseconds):
+
+```elixir
+use ExternalService,
+  rate_limit: [
+    limit: 100,                # at most 100 calls...
+    per: :timer.seconds(1)     # ...per 1-second window
+  ]
+```
+
+| Option | Required | Meaning |
+| --- | --- | --- |
+| `:limit` | yes | Maximum number of calls allowed within each `:per` window. |
+| `:per` | yes | Length of the rate-limiting window, in milliseconds. |
+
+Both keys are required when `:rate_limit` is present.
+
+## How it works
+
+The limit is tracked per service and shared across every caller in your
+application — every process that calls the service draws from the same bucket. So
+the example above guarantees no more than 100 calls per second *in total*, no
+matter how many processes are making them.
+
+When a call would exceed the limit, `ExternalService` does not fail it. Instead
+it **sleeps** until the window has room, then proceeds. From your code's point of
+view the call simply takes a little longer; it still succeeds.
+
+```elixir
+# This will never make more than 100 calls/second, even in a tight loop —
+# excess calls sleep until the window allows them.
+Enum.each(1..10_000, fn i ->
+  MyApp.Api.fetch(i)
+end)
+```
+
+## Who sleeps?
+
+The sleeping happens in whichever process is making the call:
+
+  * With `call/1` (synchronous), the **calling process** sleeps. Your code blocks
+    until the call is allowed.
+  * With `call_async/1` and `call_async_stream/2`, the **background task(s)**
+    sleep, not your calling process. This is often what you want for bulk work:
+    kick off the stream and let the workers pace themselves.
+
+```elixir
+# Bulk import that respects the rate limit without blocking the caller:
+ids
+|> MyApp.Api.call_async_stream(fn id -> MyApp.Api.fetch(id) end)
+|> Enum.to_list()
+```
+
+## Customizing the sleep
+
+By default sleeping uses `Process.sleep/1`. In tests — where you don't want real
+delays — you can override it with `:sleep_function`:
+
+```elixir
+use ExternalService,
+  rate_limit: [limit: 100, per: :timer.seconds(1)],
+  sleep_function: fn _ms -> :ok end
+```
+
+The function receives the number of milliseconds the library would otherwise
+sleep. This is also where you'd hook in deterministic test control or custom
+instrumentation.
+
+## Observing throttling
+
+Every time a call is throttled and put to sleep, an
+`[:external_service, :rate_limit, :sleep]` telemetry event is emitted, with the
+sleep duration in its measurements. Attach a handler to track how often (and how
+long) you are being rate limited — a useful signal that you may need a higher
+quota or fewer calls. See the [Telemetry](telemetry.md) guide.
+
+## Rate limiting and the circuit breaker
+
+Rate-limit sleeps are independent of the circuit breaker: being throttled is not
+a failure and does not melt the breaker. A throttled call waits and then runs
+normally, succeeding or failing on its own merits.

--- a/guides/retries.md
+++ b/guides/retries.md
@@ -1,0 +1,176 @@
+# Retries
+
+Many failures when calling an external service are *transient*: a momentary
+timeout, a brief overload, a connection reset. The simplest effective response is
+to try again — perhaps after a short backoff. `ExternalService` automates this
+using the [retry](https://hex.pm/packages/retry) library, exposing its
+flexibility through the `ExternalService.RetryOptions` struct.
+
+## Triggering a retry
+
+Inside the function you pass to `call`, you signal that a retry should happen by
+returning either:
+
+  * the atom `:retry`, or
+  * a tuple `{:retry, reason}`, where `reason` is any term.
+
+Anything else is a success and is returned to the caller as-is — including the
+function's own `{:error, reason}` results. You decide what is retriable:
+
+```elixir
+call fn ->
+  case HTTP.post(url, body) do
+    {:ok, %{status: 200} = resp}            -> {:ok, resp}
+    {:ok, %{status: s}} when s in 500..599  -> {:retry, s}   # retry server errors
+    {:ok, %{status: 429}}                   -> :retry         # retry throttling
+    {:ok, %{status: 4xx}} = resp            -> resp           # client error: don't retry
+    {:error, reason}                        -> {:error, reason}
+  end
+end
+```
+
+Each retry melts the service's circuit breaker, so a sustained run of retries
+will eventually open it. See [Circuit breakers](circuit-breakers.md).
+
+## Configuring retries
+
+Retry behavior is described by `ExternalService.RetryOptions`. You can supply it
+as the service's default (the `:retry` option to `use ExternalService` /
+`start/2`), or per call as a keyword list or struct:
+
+```elixir
+# Service default
+use ExternalService,
+  retry: [max_attempts: 5, backoff: :exponential, base: 100, jitter: true]
+
+# Per-call override (keyword list)
+call [max_attempts: 2, backoff: :linear, base: 50], fn -> work() end
+
+# Per-call override (struct)
+call %ExternalService.RetryOptions{max_attempts: 2}, fn -> work() end
+```
+
+When you use the two-argument `call/1` (no options), the service's default
+`:retry` options apply.
+
+### The options
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `:backoff` | `:exponential` | Growth strategy for the delay between retries: `:exponential` or `:linear`. |
+| `:base` | `10` | Initial delay between retries, in milliseconds (`0` for no delay). |
+| `:factor` | `1` | Growth factor applied each retry. Only used for `:linear` backoff. |
+| `:cap` | — | Caps the delay between retries to at most this many milliseconds. |
+| `:expiry` | — | Total time budget for retries, in milliseconds. Retrying stops once exceeded. |
+| `:max_attempts` | — | Maximum number of attempts (initial plus retries). No limit by default. |
+| `:jitter` | `false` | Random jitter on delays. `true` applies ±10%; a float (e.g. `0.25`) applies that proportion. |
+| `:retry_on` | `[]` | Exception modules that should trigger a retry when raised. |
+
+Options are validated when the struct is built; an invalid value raises
+`NimbleOptions.ValidationError` with a helpful message.
+
+## Backoff strategies
+
+**Exponential** backoff grows the delay multiplicatively, starting from `:base`.
+This is the right default for most services: it backs off quickly when a service
+is struggling.
+
+```elixir
+retry: [backoff: :exponential, base: 100]
+# delays grow ~100ms, 200ms, 400ms, 800ms, ...
+```
+
+**Linear** backoff grows the delay by `:factor` each time, starting from
+`:base`:
+
+```elixir
+retry: [backoff: :linear, base: 100, factor: 1]
+# delays grow ~100ms, 200ms, 300ms, 400ms, ...
+```
+
+## Bounding retries
+
+Left unbounded, retries continue indefinitely (until the circuit breaker opens).
+You almost always want a bound. There are two, and they compose:
+
+  * **`:max_attempts`** — a count. `max_attempts: 5` means at most five attempts
+    total (the first try plus four retries).
+  * **`:expiry`** — a time budget in milliseconds. Once cumulative retry time
+    exceeds it, retrying stops.
+
+You can use either or both; whichever is reached first stops the retries. When
+the bound is hit without success, `call/3` returns
+`{:error, %ExternalService.RetriesExhausted{}}` (and `call!/3` raises it).
+
+```elixir
+# Stop after 5 attempts OR 5 seconds, whichever comes first.
+retry: [max_attempts: 5, expiry: :timer.seconds(5), backoff: :exponential, base: 100]
+```
+
+## Capping the delay
+
+Exponential backoff grows without bound. `:cap` puts a ceiling on any single
+delay so you don't end up waiting minutes between attempts:
+
+```elixir
+retry: [backoff: :exponential, base: 100, cap: :timer.seconds(2)]
+# delays grow 100, 200, 400, 800, 1600, 2000, 2000, ... (capped at 2s)
+```
+
+## Jitter
+
+When many processes retry on the same schedule, they retry in lockstep and slam
+the recovering service all at once — the *thundering herd*. Jitter randomizes
+each delay to spread them out:
+
+```elixir
+retry: [backoff: :exponential, base: 100, jitter: true]   # ±10%
+retry: [backoff: :exponential, base: 100, jitter: 0.25]   # ±25%
+```
+
+Enabling jitter is good practice for any service with many concurrent callers.
+
+## Retrying on raised exceptions
+
+**By default, raised exceptions are not retried** — they propagate straight to
+the caller. This is a deliberate 2.0 change (see
+[issue #7](https://github.com/jvoegele/external_service/issues/7)): retrying
+every `RuntimeError` by default tended to mask real bugs.
+
+If a particular exception genuinely indicates a transient condition worth
+retrying, list its module in `:retry_on`:
+
+```elixir
+retry: [retry_on: [MyApp.TransientError, DBConnection.ConnectionError]]
+```
+
+Now a raised `MyApp.TransientError` triggers a retry just like a `:retry` return
+value would; exceptions not in the list still propagate.
+
+> #### Prefer return values over exceptions {: .tip}
+>
+> Where you can, drive retries with `:retry` / `{:retry, reason}` return values
+> rather than relying on `:retry_on`. It keeps the retry decision explicit and
+> local to the call, and avoids retrying an exception that happens to share a
+> type with a genuine bug.
+
+## Putting it together
+
+A solid default for an HTTP-style dependency:
+
+```elixir
+use ExternalService,
+  circuit_breaker: [tolerate: 5, within: :timer.seconds(1), reset: :timer.seconds(5)],
+  retry: [
+    backoff: :exponential,
+    base: 100,
+    cap: :timer.seconds(2),
+    max_attempts: 5,
+    expiry: :timer.seconds(10),
+    jitter: true
+  ]
+```
+
+This retries transient failures with jittered exponential backoff, never waits
+more than 2 seconds between attempts, gives up after 5 attempts or 10 seconds,
+and lets the circuit breaker take over if the failures are sustained.

--- a/guides/retries.md
+++ b/guides/retries.md
@@ -1,6 +1,6 @@
 # Retries
 
-Many failures when calling an external service are *transient*: a momentary
+Many failures when calling an external service are _transient_: a momentary
 timeout, a brief overload, a connection reset. The simplest effective response is
 to try again — perhaps after a short backoff. `ExternalService` automates this
 using the [retry](https://hex.pm/packages/retry) library, exposing its
@@ -11,8 +11,8 @@ flexibility through the `ExternalService.RetryOptions` struct.
 Inside the function you pass to `call`, you signal that a retry should happen by
 returning either:
 
-  * the atom `:retry`, or
-  * a tuple `{:retry, reason}`, where `reason` is any term.
+- the atom `:retry`, or
+- a tuple `{:retry, reason}`, where `reason` is any term.
 
 Anything else is a success and is returned to the caller as-is — including the
 function's own `{:error, reason}` results. You decide what is retriable:
@@ -22,8 +22,8 @@ call fn ->
   case HTTP.post(url, body) do
     {:ok, %{status: 200} = resp}            -> {:ok, resp}
     {:ok, %{status: s}} when s in 500..599  -> {:retry, s}   # retry server errors
-    {:ok, %{status: 429}}                   -> :retry         # retry throttling
-    {:ok, %{status: 4xx}} = resp            -> resp           # client error: don't retry
+    {:ok, %{status: 429}}                   -> :retry        # retry throttling
+    {:ok, %{status: 4xx}} = resp            -> resp          # client error: don't retry
     {:error, reason}                        -> {:error, reason}
   end
 end
@@ -50,21 +50,21 @@ call [max_attempts: 2, backoff: :linear, base: 50], fn -> work() end
 call %ExternalService.RetryOptions{max_attempts: 2}, fn -> work() end
 ```
 
-When you use the two-argument `call/1` (no options), the service's default
+When you use the two-argument `call/2` (no options), the service's default
 `:retry` options apply.
 
 ### The options
 
-| Option | Default | Meaning |
-| --- | --- | --- |
-| `:backoff` | `:exponential` | Growth strategy for the delay between retries: `:exponential` or `:linear`. |
-| `:base` | `10` | Initial delay between retries, in milliseconds (`0` for no delay). |
-| `:factor` | `1` | Growth factor applied each retry. Only used for `:linear` backoff. |
-| `:cap` | — | Caps the delay between retries to at most this many milliseconds. |
-| `:expiry` | — | Total time budget for retries, in milliseconds. Retrying stops once exceeded. |
-| `:max_attempts` | — | Maximum number of attempts (initial plus retries). No limit by default. |
-| `:jitter` | `false` | Random jitter on delays. `true` applies ±10%; a float (e.g. `0.25`) applies that proportion. |
-| `:retry_on` | `[]` | Exception modules that should trigger a retry when raised. |
+| Option          | Default        | Meaning                                                                                      |
+| --------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `:backoff`      | `:exponential` | Growth strategy for the delay between retries: `:exponential` or `:linear`.                  |
+| `:base`         | `10`           | Initial delay between retries, in milliseconds (`0` for no delay).                           |
+| `:factor`       | `1`            | Growth factor applied each retry. Only used for `:linear` backoff.                           |
+| `:cap`          | —              | Caps the delay between retries to at most this many milliseconds.                            |
+| `:expiry`       | —              | Total time budget for retries, in milliseconds. Retrying stops once exceeded.                |
+| `:max_attempts` | —              | Maximum number of attempts (initial plus retries). No limit by default.                      |
+| `:jitter`       | `false`        | Random jitter on delays. `true` applies ±10%; a float (e.g. `0.25`) applies that proportion. |
+| `:retry_on`     | `[]`           | Exception modules that should trigger a retry when raised.                                   |
 
 Options are validated when the struct is built; an invalid value raises
 `NimbleOptions.ValidationError` with a helpful message.
@@ -93,10 +93,10 @@ retry: [backoff: :linear, base: 100, factor: 1]
 Left unbounded, retries continue indefinitely (until the circuit breaker opens).
 You almost always want a bound. There are two, and they compose:
 
-  * **`:max_attempts`** — a count. `max_attempts: 5` means at most five attempts
-    total (the first try plus four retries).
-  * **`:expiry`** — a time budget in milliseconds. Once cumulative retry time
-    exceeds it, retrying stops.
+- **`:max_attempts`** — a count. `max_attempts: 5` means at most five attempts
+  total (the first try plus four retries).
+- **`:expiry`** — a time budget in milliseconds. Once cumulative retry time
+  exceeds it, retrying stops.
 
 You can use either or both; whichever is reached first stops the retries. When
 the bound is hit without success, `call/3` returns
@@ -120,7 +120,7 @@ retry: [backoff: :exponential, base: 100, cap: :timer.seconds(2)]
 ## Jitter
 
 When many processes retry on the same schedule, they retry in lockstep and slam
-the recovering service all at once — the *thundering herd*. Jitter randomizes
+the recovering service all at once — the _thundering herd_. Jitter randomizes
 each delay to spread them out:
 
 ```elixir

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -1,0 +1,135 @@
+# Telemetry
+
+`ExternalService` emits [`:telemetry`](https://hexdocs.pm/telemetry) events so
+that calls to external services can be observed and instrumented. Attach a
+handler to forward them to your metrics or logging backend — StatsD, Prometheus
+(via `TelemetryMetrics`), structured logs, or anything else.
+
+Every event carries a `:service` key in its metadata identifying the service it
+relates to.
+
+## The events
+
+### `[:external_service, :call, :start]`
+
+Emitted when a guarded call begins.
+
+  * **Measurements:** `:system_time`, `:monotonic_time`
+  * **Metadata:** `:service`
+
+### `[:external_service, :call, :stop]`
+
+Emitted when a guarded call completes — including when it completes with an error
+value such as `ExternalService.RetriesExhausted` or
+`ExternalService.CircuitBreakerOpen`.
+
+  * **Measurements:** `:duration`, `:monotonic_time`
+  * **Metadata:** `:service`, `:result` (the value returned from the call)
+
+### `[:external_service, :call, :exception]`
+
+Emitted when a guarded call raises — for example a non-retriable exception from
+your function, or `call!/3` raising on an open breaker or exhausted retries.
+
+  * **Measurements:** `:duration`, `:monotonic_time`
+  * **Metadata:** `:service`, `:kind`, `:reason`, `:stacktrace`
+
+### `[:external_service, :call, :retry]`
+
+Emitted each time a call's function fails in a way that melts the circuit breaker
+(it returned `:retry` / `{:retry, reason}`, or it raised). Whether another
+attempt is actually made depends on the retry options.
+
+  * **Measurements:** `:count` (always `1`)
+  * **Metadata:** `:service`, `:reason`
+
+### `[:external_service, :circuit_breaker, :blown]`
+
+Emitted when a call is rejected because the service's circuit breaker is open.
+
+  * **Measurements:** `:count` (always `1`)
+  * **Metadata:** `:service`
+
+### `[:external_service, :rate_limit, :sleep]`
+
+Emitted when a call is throttled and put to sleep to stay within the configured
+rate limit.
+
+  * **Measurements:** `:sleep_time` (milliseconds)
+  * **Metadata:** `:service`
+
+> #### Event names are a stable contract {: .info}
+>
+> The event names use `:circuit_breaker` (not the underlying `:fuse`)
+> deliberately, so they remained stable through the 2.0 terminology changes.
+> Treat them as a public API you can build dashboards on.
+
+The `:call` events form a [`:telemetry.span/3`](https://hexdocs.pm/telemetry/telemetry.html#span/3),
+so `:start` is always paired with either `:stop` or `:exception`, and the
+`:duration` measurement is directly usable as call latency.
+
+## Attaching a handler
+
+A minimal handler that logs retries and breaker trips:
+
+```elixir
+:telemetry.attach_many(
+  "external-service-logger",
+  [
+    [:external_service, :call, :retry],
+    [:external_service, :circuit_breaker, :blown],
+    [:external_service, :rate_limit, :sleep]
+  ],
+  &MyApp.ServiceTelemetry.handle_event/4,
+  nil
+)
+
+defmodule MyApp.ServiceTelemetry do
+  require Logger
+
+  def handle_event([:external_service, :call, :retry], _measurements, %{service: svc, reason: reason}, _config) do
+    Logger.warning("Retrying #{inspect(svc)}: #{inspect(reason)}")
+  end
+
+  def handle_event([:external_service, :circuit_breaker, :blown], _measurements, %{service: svc}, _config) do
+    Logger.error("Circuit breaker open for #{inspect(svc)}")
+  end
+
+  def handle_event([:external_service, :rate_limit, :sleep], %{sleep_time: ms}, %{service: svc}, _config) do
+    Logger.info("Rate limited #{inspect(svc)}; slept #{ms}ms")
+  end
+end
+```
+
+Attach handlers once at application start (for example in your
+`Application.start/2`).
+
+## With Telemetry.Metrics
+
+If you use [`Telemetry.Metrics`](https://hexdocs.pm/telemetry_metrics), the
+events map cleanly onto metric definitions:
+
+```elixir
+import Telemetry.Metrics
+
+[
+  # Call latency, tagged by service.
+  summary("external_service.call.stop.duration",
+    unit: {:native, :millisecond},
+    tags: [:service]
+  ),
+
+  # How often calls fail and trigger a retry.
+  counter("external_service.call.retry.count", tags: [:service]),
+
+  # How often the breaker trips.
+  counter("external_service.circuit_breaker.blown.count", tags: [:service]),
+
+  # Time lost to rate-limit throttling.
+  sum("external_service.rate_limit.sleep.sleep_time", tags: [:service])
+]
+```
+
+These four signals — latency, retry rate, breaker trips, and throttle time —
+give you a clear, per-service picture of the health of every external dependency
+your application relies on.

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -14,8 +14,8 @@ relates to.
 
 Emitted when a guarded call begins.
 
-  * **Measurements:** `:system_time`, `:monotonic_time`
-  * **Metadata:** `:service`
+- **Measurements:** `:system_time`, `:monotonic_time`
+- **Metadata:** `:service`
 
 ### `[:external_service, :call, :stop]`
 
@@ -23,16 +23,16 @@ Emitted when a guarded call completes — including when it completes with an er
 value such as `ExternalService.RetriesExhausted` or
 `ExternalService.CircuitBreakerOpen`.
 
-  * **Measurements:** `:duration`, `:monotonic_time`
-  * **Metadata:** `:service`, `:result` (the value returned from the call)
+- **Measurements:** `:duration`, `:monotonic_time`
+- **Metadata:** `:service`, `:result` (the value returned from the call)
 
 ### `[:external_service, :call, :exception]`
 
 Emitted when a guarded call raises — for example a non-retriable exception from
 your function, or `call!/3` raising on an open breaker or exhausted retries.
 
-  * **Measurements:** `:duration`, `:monotonic_time`
-  * **Metadata:** `:service`, `:kind`, `:reason`, `:stacktrace`
+- **Measurements:** `:duration`, `:monotonic_time`
+- **Metadata:** `:service`, `:kind`, `:reason`, `:stacktrace`
 
 ### `[:external_service, :call, :retry]`
 
@@ -40,23 +40,23 @@ Emitted each time a call's function fails in a way that melts the circuit breake
 (it returned `:retry` / `{:retry, reason}`, or it raised). Whether another
 attempt is actually made depends on the retry options.
 
-  * **Measurements:** `:count` (always `1`)
-  * **Metadata:** `:service`, `:reason`
+- **Measurements:** `:count` (always `1`)
+- **Metadata:** `:service`, `:reason`
 
 ### `[:external_service, :circuit_breaker, :blown]`
 
 Emitted when a call is rejected because the service's circuit breaker is open.
 
-  * **Measurements:** `:count` (always `1`)
-  * **Metadata:** `:service`
+- **Measurements:** `:count` (always `1`)
+- **Metadata:** `:service`
 
 ### `[:external_service, :rate_limit, :sleep]`
 
 Emitted when a call is throttled and put to sleep to stay within the configured
 rate limit.
 
-  * **Measurements:** `:sleep_time` (milliseconds)
-  * **Metadata:** `:service`
+- **Measurements:** `:sleep_time` (milliseconds)
+- **Metadata:** `:service`
 
 > #### Event names are a stable contract {: .info}
 >

--- a/guides/the-front-door.md
+++ b/guides/the-front-door.md
@@ -1,0 +1,149 @@
+# The Module Front Door
+
+`use ExternalService` is the recommended, declarative way to define a gateway to
+an external service. You configure the circuit breaker, rate limiting, and
+default retry options once at the module level, start the module under a
+supervisor, and call the service through a small set of generated functions.
+
+This guide covers what `use ExternalService` generates and how to operate it.
+For the mechanics of each subsystem, see the [Circuit breakers](circuit-breakers.md),
+[Retries](retries.md), and [Rate limiting](rate-limiting.md) guides.
+
+## Defining a service
+
+```elixir
+defmodule MyApp.Stripe do
+  use ExternalService,
+    circuit_breaker: [tolerate: 5, within: :timer.seconds(1), reset: :timer.seconds(5)],
+    rate_limit: [limit: 100, per: :timer.seconds(1)],
+    retry: [max_attempts: 5, backoff: :exponential, jitter: true]
+
+  def charge(params) do
+    call fn ->
+      case Stripe.charge(params) do
+        {:ok, result} -> {:ok, result}
+        {:error, %{status: status}} when status in 500..599 -> :retry
+        other -> other
+      end
+    end
+  end
+end
+```
+
+The options are exactly those accepted by `ExternalService.start/2`
+(`:circuit_breaker`, `:rate_limit`, `:retry`, `:sleep_function`), plus:
+
+  * `:name` — the term that identifies the service. Defaults to the module name.
+
+You rarely need `:name`; the module name is a perfectly good service identifier
+and keeps things unambiguous.
+
+## Starting the service
+
+A service must be started before it is called. Starting installs the circuit
+breaker and rate limiter and records the default retry options. Because `use
+ExternalService` generates `child_spec/1`, you can place the module directly in
+a supervision tree:
+
+```elixir
+children = [
+  MyApp.Stripe
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+```
+
+Under the hood the generated `start_link/1` installs the service's circuit
+breaker and rate limiter. This is the only "process" the front door adds, and it
+exists purely to tie the service's lifecycle to your supervision tree.
+
+## Per-environment overrides
+
+The child spec accepts overrides that are **deep merged** with the options given
+to `use ExternalService`. This is the idiomatic way to tune a service per
+environment — most usefully, to make tests fast and deterministic:
+
+```elixir
+# config-driven children
+children = [
+  {MyApp.Stripe, circuit_breaker: [tolerate: 1], retry: [max_attempts: 1]}
+]
+```
+
+Because the merge is deep, you only override the keys you care about; everything
+else falls back to the module-level configuration. For example, the override
+above keeps the `:within` and `:reset` from the module and only changes
+`:tolerate`.
+
+## Generated functions
+
+`use ExternalService` generates the following functions on your module:
+
+| Function | Delegates to | Purpose |
+| --- | --- | --- |
+| `call/1`, `call/2` | `ExternalService.call/2,3` | Synchronous guarded call. |
+| `call!/1`, `call!/2` | `ExternalService.call!/2,3` | Like `call`, but raises on failure. |
+| `call_async/1`, `call_async/2` | `ExternalService.call_async/2,3` | Returns a `Task`. |
+| `call_async_stream/2,3,4` | `ExternalService.call_async_stream/3,4,5` | Parallel, streaming calls. |
+| `available?/0` | `ExternalService.available?/1` | Is the breaker closed? |
+| `blown?/0` | `ExternalService.blown?/1` | Is the breaker open? |
+| `reset/0` | `ExternalService.reset/1` | Force the breaker closed. |
+| `child_spec/1`, `start_link/1` | — | Supervision integration. |
+
+The one- and two-argument `call` forms differ only in whether you pass retry
+options explicitly:
+
+```elixir
+# Uses the module's default :retry options
+call fn -> do_work() end
+
+# Overrides them for this call only
+call [max_attempts: 2, backoff: :linear, base: 50], fn -> do_work() end
+```
+
+See the [Retries](retries.md) guide for what the override keyword list accepts.
+
+## Introspection
+
+The generated `available?/0`, `blown?/0`, and `reset/0` let you inspect and
+control the circuit breaker without referring to the service name:
+
+```elixir
+if MyApp.Stripe.available?() do
+  MyApp.Stripe.charge(params)
+else
+  {:error, :payments_unavailable}
+end
+```
+
+`available?/0` returns `true` when the breaker is closed (calls will be
+attempted) and `false` when it is open or the service has not been started.
+`blown?/0` is the direct "is the breaker open?" question. See
+[Circuit breakers](circuit-breakers.md) for the semantics and caveats.
+
+## Relationship to the functional API
+
+Everything the front door generates is a thin wrapper over the functional
+`ExternalService` API (`start/2`, `call/3`, `call!/3`, `call_async/3`,
+`call_async_stream/5`, `available?/1`, `blown?/1`, `reset/1`). Reach for the
+functional API directly when a service identifier isn't naturally a module — for
+example, when you start services dynamically or key them on runtime values:
+
+```elixir
+ExternalService.start({:tenant, tenant_id},
+  circuit_breaker: [tolerate: 5, within: 1_000]
+)
+
+ExternalService.call({:tenant, tenant_id}, fn -> fetch(tenant_id) end)
+```
+
+The two styles interoperate freely; the front door is just the ergonomic
+default.
+
+## Migrating from `ExternalService.Gateway`
+
+`use ExternalService.Gateway` (the 1.x module-based gateway) still works but is
+**deprecated** and emits a warning at compile time. It delegates to `use
+ExternalService` and keeps the old `external_call/*` and `reset_fuse/0` names as
+aliases — but it uses the new option shape, so the old `fuse: [...]` options are
+gone. See [Migrating to 2.0](migrating-to-2.0.md) for the mapping.

--- a/guides/the-front-door.md
+++ b/guides/the-front-door.md
@@ -33,7 +33,7 @@ end
 The options are exactly those accepted by `ExternalService.start/2`
 (`:circuit_breaker`, `:rate_limit`, `:retry`, `:sleep_function`), plus:
 
-  * `:name` — the term that identifies the service. Defaults to the module name.
+- `:name` — the term that identifies the service. Defaults to the module name.
 
 You rarely need `:name`; the module name is a perfectly good service identifier
 and keeps things unambiguous.
@@ -79,16 +79,16 @@ above keeps the `:within` and `:reset` from the module and only changes
 
 `use ExternalService` generates the following functions on your module:
 
-| Function | Delegates to | Purpose |
-| --- | --- | --- |
-| `call/1`, `call/2` | `ExternalService.call/2,3` | Synchronous guarded call. |
-| `call!/1`, `call!/2` | `ExternalService.call!/2,3` | Like `call`, but raises on failure. |
-| `call_async/1`, `call_async/2` | `ExternalService.call_async/2,3` | Returns a `Task`. |
-| `call_async_stream/2,3,4` | `ExternalService.call_async_stream/3,4,5` | Parallel, streaming calls. |
-| `available?/0` | `ExternalService.available?/1` | Is the breaker closed? |
-| `blown?/0` | `ExternalService.blown?/1` | Is the breaker open? |
-| `reset/0` | `ExternalService.reset/1` | Force the breaker closed. |
-| `child_spec/1`, `start_link/1` | — | Supervision integration. |
+| Function                       | Delegates to                              | Purpose                             |
+| ------------------------------ | ----------------------------------------- | ----------------------------------- |
+| `call/1`, `call/2`             | `ExternalService.call/2,3`                | Synchronous guarded call.           |
+| `call!/1`, `call!/2`           | `ExternalService.call!/2,3`               | Like `call`, but raises on failure. |
+| `call_async/1`, `call_async/2` | `ExternalService.call_async/2,3`          | Returns a `Task`.                   |
+| `call_async_stream/2,3,4`      | `ExternalService.call_async_stream/3,4,5` | Parallel, streaming calls.          |
+| `available?/0`                 | `ExternalService.available?/1`            | Is the breaker closed?              |
+| `blown?/0`                     | `ExternalService.blown?/1`                | Is the breaker open?                |
+| `reset/0`                      | `ExternalService.reset/1`                 | Force the breaker closed.           |
+| `child_spec/1`, `start_link/1` | —                                         | Supervision integration.            |
 
 The one- and two-argument `call` forms differ only in whether you pass retry
 options explicitly:

--- a/mix.exs
+++ b/mix.exs
@@ -71,11 +71,37 @@ defmodule ExternalService.Mixfile do
 
   defp docs do
     [
-      main: "readme",
+      main: "getting-started",
       extras: [
+        "guides/getting-started.md",
+        "guides/the-front-door.md",
+        "guides/circuit-breakers.md",
+        "guides/retries.md",
+        "guides/rate-limiting.md",
+        "guides/error-handling.md",
+        "guides/telemetry.md",
+        "guides/cheatsheet.cheatmd",
+        "guides/migrating-to-2.0.md",
+        "guides/about.md",
         "README.md": [title: "Overview"],
         "CHANGELOG.md": [title: "Changelog"],
         LICENSE: [title: "License"]
+      ],
+      groups_for_extras: [
+        Guides: [
+          "guides/getting-started.md",
+          "guides/the-front-door.md",
+          "guides/circuit-breakers.md",
+          "guides/retries.md",
+          "guides/rate-limiting.md",
+          "guides/error-handling.md",
+          "guides/telemetry.md"
+        ],
+        Reference: [
+          "guides/cheatsheet.cheatmd",
+          "guides/migrating-to-2.0.md",
+          "guides/about.md"
+        ]
       ],
       filter_modules: fn _module, meta ->
         # Tag modules with `@moduledoc internal: true` to exclude them from docs.


### PR DESCRIPTION
## M5 — Documentation overhaul

Splits the long-form README into a set of HexDocs guides (mirroring the structure of the sibling libraries) and rewrites the README as a concise, 2.0-accurate overview that links into them. Also writes the **1.x → 2.0 migration guide** the CHANGELOG kept referencing.

### Guides added (`guides/`)
**Guides group**
- `getting-started.md` — first reliable call, retries + breaker + supervision
- `the-front-door.md` — everything `use ExternalService` generates, overrides, functional API relationship
- `circuit-breakers.md` — trip/reset semantics, melt-vs-retry, introspection, fault injection
- `retries.md` — backoff, jitter, `max_attempts`/`expiry`, `retry_on` (incl. the #7 default change)
- `rate-limiting.md` — quotas, who-sleeps, `sleep_function`, telemetry
- `error-handling.md` — `call` vs `call!`, the structured error types

**Reference group**
- `telemetry.md` — every event with measurements/metadata, attach + `Telemetry.Metrics` examples
- `cheatsheet.cheatmd` — at-a-glance recipes
- `migrating-to-2.0.md` — step-by-step upgrade with an end-of-page checklist
- `about.md` — concepts + project history

### Wiring
- `mix.exs`: `extras` + `groups_for_extras`; docs landing page (`main`) is now Getting Started.
- README slimmed to a 2.0-accurate quick start (the old README documented the removed 1.x API).
- CHANGELOG links the migration guide instead of promising one; adds a docs entry. ROADMAP M5 ✓.

### Verification
- `mix docs --warnings-as-errors` builds clean.
- `mix format --check-formatted` clean.
- `mix test` — 69 tests, 0 failures.

No library source changed; this is docs + docs-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)