### PR TITLE
Add retry_on result predicate; rename exception list to retry_exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Local scratch (announcement drafts, etc.)
+.tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `RetryOptions.retry_on` now accepts a **predicate over the return value**, so
+  retries can be driven from a function that does not itself return
+  `:retry` / `{:retry, reason}` (the common case when adapting an existing client
+  function). When the predicate returns a truthy value the call is retried — the
+  result becomes the retry reason and the circuit breaker melts — exactly like an
+  explicit `:retry` return, which still takes precedence
+  ([issue #29](https://github.com/jvoegele/external_service/issues/29)).
+
+### Changed (breaking)
+- Renamed the exception-list retry option **`retry_on` → `retry_exceptions`**
+  (relative to `2.0.0-rc.1`) to free the concise `:retry_on` name for the new
+  result predicate above. The 1.x → 2.0 mapping is now
+  `rescue_only:` → `retry_exceptions:`. `:retry_on` now expects an arity-1
+  function, so a leftover `retry_on: [SomeError]` from `rc.1` raises a
+  `NimbleOptions.ValidationError` at `start/2`.
+
 ## [2.0.0-rc.1] - 2026-06-18
 
 First release candidate for 2.0. The 2.0 line modernizes the project and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+## Project overview
+- `external_service` is an Elixir library that provides retry logic, circuit breaker behavior, and optional rate limiting for external API/service calls.
+- Core API and behavior live in `lib/external_service.ex`.
+- Supporting modules:
+  - `lib/external_service/retry_options.ex`
+  - `lib/external_service/rate_limit.ex`
+  - `lib/external_service/gateway.ex`
+
+## Repository structure
+- `lib/` — library source code.
+- `test/` — ExUnit test suite.
+  - `test/external_service_test.exs` covers the main `ExternalService` module.
+  - `test/external_service/` contains focused tests for gateway and rate limiting.
+- `config/config.exs` — project configuration.
+- `README.md` — detailed usage docs and examples.
+- `doc/` — additional documentation assets.
+
+## Common development commands
+- Install dependencies:
+  - `mix deps.get`
+- Run tests:
+  - `mix test`
+- Format code:
+  - `mix format`
+- Generate docs:
+  - `mix docs`
+- Optional quality checks (if used in local workflow):
+  - `mix credo`
+  - `mix dialyzer`
+
+## Editing guidance
+- Keep public API behavior in `ExternalService` backward-compatible unless explicitly changing a documented contract.
+- Follow existing patterns for:
+  - return values (`:retry`, `{:retry, reason}`, and error tuples),
+  - error/exception handling (`call/3` vs `call!/3`),
+  - typedocs and `@spec` coverage.
+- Prefer focused tests near the behavior being changed:
+  - add/adjust tests in `test/external_service_test.exs` for core API behavior,
+  - use module-specific test files under `test/external_service/` for helper modules.
+
+## Notes
+- The project is a library (not a full OTP app with a running supervision tree in this repo).
+- Fuse initialization via `ExternalService.start/2` is expected before making guarded calls.

--- a/guides/cheatsheet.cheatmd
+++ b/guides/cheatsheet.cheatmd
@@ -81,8 +81,9 @@ end
 | --- | --- |
 | `:retry` | retry |
 | `{:retry, reason}` | retry (reason recorded) |
+| value matched by `:retry_on` predicate | retry (result recorded as reason) |
 | anything else | success, returned as-is |
-| raised exception | propagates (retried only if in `:retry_on`) |
+| raised exception | propagates (retried only if in `:retry_exceptions`) |
 
 ## Circuit breaker config
 {: .col-2}
@@ -121,7 +122,8 @@ retry: [
   max_attempts: 5,         # attempt count bound
   expiry: :timer.seconds(10), # time budget ms
   jitter: true,            # ±10%, or a float proportion
-  retry_on: []             # exception modules to retry
+  retry_on: &match?({:error, _}, &1), # predicate over the result
+  retry_exceptions: []     # exception modules to retry
 ]
 ```
 
@@ -136,7 +138,10 @@ retry: [backoff: :exponential, base: 100, cap: 2_000,
         max_attempts: 5, jitter: true]
 
 # Retry a transient exception
-retry: [retry_on: [MyApp.TransientError]]
+retry: [retry_exceptions: [MyApp.TransientError]]
+
+# Retry on the result of an unmodified function
+retry: [retry_on: &match?({:error, %{status: 500}}, &1)]
 ```
 
 ## Error handling

--- a/guides/circuit-breakers.md
+++ b/guides/circuit-breakers.md
@@ -58,20 +58,21 @@ The breaker is "melted" — pushed one step toward opening — on every call att
 that fails, where a failure is:
 
 - the function returns `:retry` or `{:retry, reason}`, or
-- the function raises an exception whose type is listed in the `:retry_on` retry
-  option.
+- the function returns a value matched by the `:retry_on` predicate, or
+- the function raises an exception whose type is listed in the `:retry_exceptions`
+  retry option.
 
 > #### Melt and retry go together for exceptions {: .info}
 >
-> The `:retry_on` retry option governs **both** whether a raised exception is
-> retried **and** whether it melts the breaker. An exception whose type is in
-> `:retry_on` is retried and melts the breaker; an exception that is *not* in
-> `:retry_on` is neither retried nor melted — it propagates to the caller and
-> leaves the breaker untouched.
+> The `:retry_exceptions` retry option governs **both** whether a raised exception
+> is retried **and** whether it melts the breaker. An exception whose type is in
+> `:retry_exceptions` is retried and melts the breaker; an exception that is *not*
+> in `:retry_exceptions` is neither retried nor melted — it propagates to the
+> caller and leaves the breaker untouched.
 >
-> Explicit `:retry` / `{:retry, reason}` return values always melt the breaker;
-> they are the protocol for asking for another attempt, so `:retry_on` does not
-> apply to them.
+> Explicit `:retry` / `{:retry, reason}` return values, and results matched by the
+> `:retry_on` predicate, always melt the breaker — they are ways of asking for
+> another attempt.
 
 Values your function simply returns — including its own `{:error, reason}` — are
 successes as far as the breaker is concerned and do not melt it.

--- a/guides/error-handling.md
+++ b/guides/error-handling.md
@@ -113,8 +113,8 @@ Remember that, by default, exceptions raised by your wrapped function are **not
 retried** â€” they propagate to the caller (out of both `call/3` and `call!/3`).
 They are also not converted into `ExternalService` error types; a raised
 `MyApp.HTTPError` comes out of `call` as a raised `MyApp.HTTPError`. If you want
-such an exception retried, add its module to the `:retry_on` retry option (see
-[Retries](retries.md)). If you want it returned rather than raised, catch it
+such an exception retried, add its module to the `:retry_exceptions` retry option
+(see [Retries](retries.md)). If you want it returned rather than raised, catch it
 inside your function and return an `{:error, reason}` (or `{:retry, reason}`)
 value.
 
@@ -124,5 +124,5 @@ in a linked `Task`, so an exception that propagates out of it crashes the task â
 down if you don't await. In `call_async_stream/2`, an exception raised for one
 element exits that task and, by default, propagates out of the stream. So for
 background and bulk work, prefer returning `{:error, reason}` / `{:retry, reason}`
-values (or listing the exception in `:retry_on`) over letting exceptions escape,
+values (or listing the exception in `:retry_exceptions`) over letting exceptions escape,
 so one bad element can't crash the batch.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -124,8 +124,9 @@ end
 
 By default, **raised exceptions are not retried** — they propagate to the
 caller. If you want an exception type to trigger a retry, list it in the
-`:retry_on` retry option. See the [Retries](retries.md) guide for the full set
-of retry knobs.
+`:retry_exceptions` retry option; to retry based on the return value of a function
+you don't want to modify, use the `:retry_on` predicate. See the
+[Retries](retries.md) guide for the full set of retry knobs.
 
 ## Handling failures
 

--- a/guides/migrating-to-2.0.md
+++ b/guides/migrating-to-2.0.md
@@ -23,7 +23,7 @@ sections below in order; each shows the 1.x form and its 2.0 replacement.
 | Service identifier term   | `fuse_name`                                                | `service`                                            |
 | Reset a breaker           | `reset_fuse/1`                                             | `reset/1`                                            |
 | Retry backoff             | `{:exponential, d}` / `{:linear, d, f}`                    | `backoff: :exponential\|:linear` + `base:`/`factor:` |
-| Retry on exceptions       | `rescue_only: [...]` (retried `RuntimeError` by default)   | `retry_on: [...]`, default `[]`                      |
+| Retry on exceptions       | `rescue_only: [...]` (retried `RuntimeError` by default)   | `retry_exceptions: [...]`, default `[]`              |
 | Jitter                    | `randomize:`                                               | `jitter:`                                            |
 | Module gateway            | `use ExternalService.Gateway` + `external_call/*`          | `use ExternalService` + `call/*`                     |
 | Library errors (returned) | nested tuples                                              | structured `Errata` structs                          |
@@ -86,7 +86,7 @@ alias — see section 7.)
 
 `ExternalService.RetryOptions` changed shape. Backoff is now a plain atom plus
 separate numeric fields, `randomize` became `jitter`, and `rescue_only` became
-`retry_on`.
+`retry_exceptions`.
 
 ```elixir
 # Before (1.x)
@@ -101,7 +101,7 @@ separate numeric fields, `randomize` became `jitter`, and `rescue_only` became
   backoff: :exponential,
   base: 100,
   jitter: true,
-  retry_on: [RuntimeError]
+  retry_exceptions: [RuntimeError]
 }
 ```
 
@@ -110,7 +110,11 @@ Mapping:
 - `backoff: {:exponential, delay}` → `backoff: :exponential, base: delay`
 - `backoff: {:linear, delay, factor}` → `backoff: :linear, base: delay, factor: factor`
 - `randomize: true` → `jitter: true` (a float still means that proportion)
-- `rescue_only: mods` → `retry_on: mods`
+- `rescue_only: mods` → `retry_exceptions: mods`
+
+The freed-up `:retry_on` name now takes a **predicate over the return value** —
+a way to drive retries from a function that doesn't return `:retry`. See the
+[Retries](retries.md) guide.
 
 You can also now pass retry options as a plain keyword list to `call/3` /
 `call!/3` and to the `:retry` option, not only as a struct.
@@ -119,14 +123,14 @@ You can also now pass retry options as a plain keyword list to `call/3` /
 
 This is the one change that can alter runtime behavior rather than just syntax.
 In 1.x, `rescue_only` defaulted to `[RuntimeError]`, so any raised `RuntimeError`
-was retried automatically. In 2.0, **`retry_on` defaults to `[]`** — raised
+was retried automatically. In 2.0, **`retry_exceptions` defaults to `[]`** — raised
 exceptions are _not_ retried unless you opt in
 ([issue #7](https://github.com/jvoegele/external_service/issues/7)).
 
 If you were relying on exceptions being retried, restore it explicitly:
 
 ```elixir
-retry: [retry_on: [RuntimeError]]
+retry: [retry_exceptions: [RuntimeError]]
 ```
 
 But prefer driving retries with `:retry` / `{:retry, reason}` return values where
@@ -255,8 +259,8 @@ Renames at the call site: `external_call` → `call`, `external_call!` → `call
 - [ ] `fuse_strategy:`/`fuse_refresh:` → `circuit_breaker: [tolerate:, within:, reset:]`.
 - [ ] `rate_limit: {l, w}` → `rate_limit: [limit: l, per: w]`.
 - [ ] `reset_fuse/1` → `reset/1`.
-- [ ] `RetryOptions`: tuple backoff → atom `backoff:` + `base:`/`factor:`; `randomize:` → `jitter:`; `rescue_only:` → `retry_on:`.
-- [ ] Re-add `retry_on: [RuntimeError]` only where you actually want exceptions retried.
+- [ ] `RetryOptions`: tuple backoff → atom `backoff:` + `base:`/`factor:`; `randomize:` → `jitter:`; `rescue_only:` → `retry_exceptions:`.
+- [ ] Re-add `retry_exceptions: [RuntimeError]` only where you actually want exceptions retried.
 - [ ] Replace error tuples with the structured `RetriesExhausted` / `CircuitBreakerOpen` / `ServiceNotStarted` structs.
 - [ ] Replace the old `*Error` modules in `rescue` clauses.
 - [ ] (Recommended) Move `use ExternalService.Gateway` modules to `use ExternalService`.

--- a/guides/retries.md
+++ b/guides/retries.md
@@ -32,6 +32,34 @@ end
 Each retry melts the service's circuit breaker, so a sustained run of retries
 will eventually open it. See [Circuit breakers](circuit-breakers.md).
 
+## Retrying on the return value with `:retry_on`
+
+Returning `:retry` works when you control the function body. When you're calling
+an existing function that already returns its own result shape — and you'd rather
+not wrap it just to translate that shape into `:retry` — the `:retry_on` retry
+option takes a **predicate** that is run on the return value. When the predicate
+returns a truthy value, the call is retried exactly as if the function had
+returned `{:retry, result}`: the result becomes the retry reason, and the circuit
+breaker melts.
+
+```elixir
+# Retry any 5xx response from an unmodified client function.
+retry: [retry_on: &match?({:error, %{status: s}} when s in 500..599, &1)]
+
+call fn -> Stripe.charge(params) end
+```
+
+If retries are exhausted, the matched result is carried as the reason on
+`ExternalService.RetriesExhausted` (and in the `[:external_service, :call, :retry]`
+telemetry metadata). An explicit `:retry` / `{:retry, reason}` return from the
+function always takes precedence over the predicate.
+
+> #### Prefer explicit returns when you own the function {: .tip}
+>
+> `:retry_on` is for adapting functions you don't want to change. When you do
+> control the body, returning `:retry` / `{:retry, reason}` keeps the retry
+> decision explicit and local to the call.
+
 ## Configuring retries
 
 Retry behavior is described by `ExternalService.RetryOptions`. You can supply it
@@ -77,7 +105,8 @@ When you use the two-argument `call/2` (no options), the service's default
 | `:expiry`       | —              | Total time budget for retries, in milliseconds. Retrying stops once exceeded.                |
 | `:max_attempts` | —              | Maximum number of attempts (initial plus retries). No limit by default.                      |
 | `:jitter`       | `false`        | Random jitter on delays. `true` applies ±10%; a float (e.g. `0.25`) applies that proportion. |
-| `:retry_on`     | `[]`           | Exception modules that should trigger a retry when raised.                                   |
+| `:retry_on`     | —              | Predicate run on the return value; retry when it returns a truthy value (see below).        |
+| `:retry_exceptions` | `[]`       | Exception modules that should trigger a retry when raised.                                   |
 
 Options are validated when the struct is built; an invalid value raises
 `NimbleOptions.ValidationError` with a helpful message.
@@ -163,23 +192,23 @@ the caller. This is a deliberate 2.0 change (see
 every `RuntimeError` by default tended to mask real bugs.
 
 If a particular exception genuinely indicates a transient condition worth
-retrying, list its module in `:retry_on`:
+retrying, list its module in `:retry_exceptions`:
 
 ```elixir
-retry: [retry_on: [MyApp.TransientError, DBConnection.ConnectionError]]
+retry: [retry_exceptions: [MyApp.TransientError, DBConnection.ConnectionError]]
 ```
 
 Now a raised `MyApp.TransientError` triggers a retry just like a `:retry` return
 value would, and it melts the circuit breaker. Exceptions not in the list still
-propagate untouched and leave the breaker alone — `:retry_on` governs both
+propagate untouched and leave the breaker alone — `:retry_exceptions` governs both
 retrying and whether a raised exception counts against the breaker.
 
 > #### Prefer return values over exceptions {: .tip}
 >
 > Where you can, drive retries with `:retry` / `{:retry, reason}` return values
-> rather than relying on `:retry_on`. It keeps the retry decision explicit and
-> local to the call, and avoids retrying an exception that happens to share a
-> type with a genuine bug.
+> (or the `:retry_on` predicate) rather than relying on `:retry_exceptions`. It
+> keeps the retry decision explicit and local to the call, and avoids retrying an
+> exception that happens to share a type with a genuine bug.
 
 ## Putting it together
 

--- a/lib/external_service.ex
+++ b/lib/external_service.ex
@@ -36,8 +36,9 @@ defmodule ExternalService do
 
     * `[:external_service, :call, :retry]` - emitted each time a call's function
       fails in a way that melts the circuit breaker: it returned `:retry` /
-      `{:retry, reason}`, or it raised an exception listed in the `:retry_on`
-      retry option. Exceptions not listed in `:retry_on` neither melt the breaker
+      `{:retry, reason}`, it returned a result matched by the `:retry_on`
+      predicate, or it raised an exception listed in the `:retry_exceptions` retry
+      option. Exceptions not listed in `:retry_exceptions` neither melt the breaker
       nor emit this event. Whether another attempt is actually made depends on the
       retry options.
       * Measurements: `:count` (always `1`)
@@ -319,10 +320,16 @@ defmodule ExternalService do
   other result is considered successful, so the operation will not be retried and the result of
   the function will be returned as the result of `call`.
 
-  Raised exceptions are only retried if their type is listed in the `:retry_on` retry option
+  For functions that were not written to return `:retry`/`{:retry, reason}`, the `:retry_on` retry
+  option takes a predicate that is run on the return value; when it returns a truthy value the call
+  is retried as though the function had returned `{:retry, result}` (the result becomes the retry
+  reason and the circuit breaker melts). An explicit `:retry`/`{:retry, reason}` return always
+  takes precedence over the predicate.
+
+  Raised exceptions are only retried if their type is listed in the `:retry_exceptions` retry option
   (which defaults to `[]`); otherwise they propagate to the caller untouched. An exception that is
-  not retried also does *not* melt the circuit breaker — `:retry_on` governs both retrying and
-  whether a raised exception counts as a circuit-breaker failure.
+  not retried also does *not* melt the circuit breaker — `:retry_exceptions` governs both retrying
+  and whether a raised exception counts as a circuit-breaker failure.
 
   `retry_opts` may be a `t:ExternalService.RetryOptions.t/0` struct or a keyword list of retry
   options. A keyword list is treated as per-call *overrides*: it is merged onto the service's
@@ -474,10 +481,10 @@ defmodule ExternalService do
   defp call_with_retry(service, retry_opts, function) do
     require Retry
 
-    Retry.retry with: apply_retry_options(retry_opts), rescue_only: retry_opts.retry_on do
+    Retry.retry with: apply_retry_options(retry_opts), rescue_only: retry_opts.retry_exceptions do
       case Fuse.ask(service, :sync) do
         :ok ->
-          try_function(service, retry_opts.retry_on, function)
+          try_function(service, retry_opts, function)
 
         :blown ->
           emit_blown(service)
@@ -538,9 +545,9 @@ defmodule ExternalService do
        when is_integer(max_attempts) and max_attempts > 0,
        do: Stream.take(stream, max_attempts - 1)
 
-  @spec try_function(service, [module()], retriable_function) ::
+  @spec try_function(service, RetryOptions.t(), retriable_function) ::
           {:error, {:retry, any}} | {:error, :retry} | {:no_retry, any} | no_return
-  defp try_function(service, retry_on, function) do
+  defp try_function(service, retry_opts, function) do
     rate_limit = State.get(service).rate_limit
 
     case RateLimit.call(rate_limit, function) do
@@ -555,15 +562,15 @@ defmodule ExternalService do
         {:error, :retry}
 
       result ->
-        {:no_retry, result}
+        maybe_retry_on_result(service, retry_opts.retry_on, result)
     end
   rescue
     error ->
       # A raised exception only counts as a failure (melting the circuit breaker)
-      # when it is one we would retry on. Exceptions not listed in `:retry_on`
-      # propagate untouched and leave the breaker alone — `:retry_on` governs both
-      # retrying and melting.
-      if retriable_exception?(error, retry_on) do
+      # when it is one we would retry on. Exceptions not listed in `:retry_exceptions`
+      # propagate untouched and leave the breaker alone — `:retry_exceptions` governs
+      # both retrying and melting.
+      if retriable_exception?(error, retry_opts.retry_exceptions) do
         emit_retry(service, error)
         Fuse.melt(service)
       end
@@ -571,10 +578,27 @@ defmodule ExternalService do
       reraise error, __STACKTRACE__
   end
 
+  # When a `:retry_on` predicate is configured, a result it matches is treated as a
+  # retry — melting the breaker and using the result itself as the retry reason —
+  # exactly like an explicit `:retry` return (which is handled before we get here,
+  # so an explicit return always takes precedence). With no predicate, or when it
+  # does not match, the result is returned untouched.
+  defp maybe_retry_on_result(_service, nil, result), do: {:no_retry, result}
+
+  defp maybe_retry_on_result(service, predicate, result) when is_function(predicate, 1) do
+    if predicate.(result) do
+      emit_retry(service, result)
+      Fuse.melt(service)
+      {:error, {:retry, result}}
+    else
+      {:no_retry, result}
+    end
+  end
+
   # Mirrors the matching done by `Retry.retry`'s `:rescue_only`: an exception is
-  # retriable when its struct is one of the modules listed in `:retry_on`.
-  defp retriable_exception?(error, retry_on) do
-    Enum.any?(retry_on, fn module -> is_struct(error, module) end)
+  # retriable when its struct is one of the modules listed in `:retry_exceptions`.
+  defp retriable_exception?(error, retry_exceptions) do
+    Enum.any?(retry_exceptions, fn module -> is_struct(error, module) end)
   end
 
   defp retries_exhausted(service, reason) do

--- a/lib/external_service/retry_options.ex
+++ b/lib/external_service/retry_options.ex
@@ -37,12 +37,22 @@ defmodule ExternalService.RetryOptions do
           "applies that proportion. Helps avoid retrying in lockstep (thundering herd)."
     ],
     retry_on: [
+      type: {:fun, 1},
+      doc:
+        "A predicate run on the *return value* of the call. When it returns a truthy value " <>
+          "the call is retried, exactly as if the function had returned `:retry` (the result " <>
+          "itself is used as the retry reason, and the circuit breaker melts). Lets you drive " <>
+          "retries from a function that was not written to return `:retry`/`{:retry, reason}`. " <>
+          "Defaults to no predicate. An explicit `:retry`/`{:retry, reason}` return always takes " <>
+          "precedence over the predicate."
+    ],
+    retry_exceptions: [
       type: {:list, :atom},
       default: [],
       doc:
         "Exception modules that should trigger a retry when raised. Defaults to `[]`, " <>
           "meaning raised exceptions are not retried; use `:retry`/`{:retry, reason}` return " <>
-          "values to drive retries instead."
+          "values, or the `:retry_on` predicate, to drive retries instead."
     ]
   ]
 
@@ -65,7 +75,8 @@ defmodule ExternalService.RetryOptions do
           expiry: pos_integer() | nil,
           max_attempts: pos_integer() | nil,
           jitter: boolean() | float(),
-          retry_on: [module()]
+          retry_on: (term() -> as_boolean(term())) | nil,
+          retry_exceptions: [module()]
         }
 
   defstruct backoff: :exponential,
@@ -75,7 +86,8 @@ defmodule ExternalService.RetryOptions do
             expiry: nil,
             max_attempts: nil,
             jitter: false,
-            retry_on: []
+            retry_on: nil,
+            retry_exceptions: []
 
   @doc """
   Builds a validated `RetryOptions` struct from a keyword list (or returns an

--- a/test/external_service_test.exs
+++ b/test/external_service_test.exs
@@ -16,17 +16,17 @@ defmodule ExternalServiceTest do
   }
 
   # Retries raised RuntimeErrors (the new default is to NOT retry exceptions).
-  @retry_on_runtime %RetryOptions{
+  @retry_runtime_errors %RetryOptions{
     backoff: :linear,
     base: 0,
-    retry_on: [RuntimeError]
+    retry_exceptions: [RuntimeError]
   }
 
   @expiring_retry_options %RetryOptions{
     backoff: :linear,
     base: 1,
     expiry: 1,
-    retry_on: [RuntimeError]
+    retry_exceptions: [RuntimeError]
   }
 
   describe "uninitialized fuse" do
@@ -115,8 +115,8 @@ defmodule ExternalServiceTest do
       assert Process.get(@fuse_name) == 1
     end
 
-    test "calls function again when it raises an exception listed in retry_on" do
-      ExternalService.call(@fuse_name, @retry_on_runtime, fn ->
+    test "calls function again when it raises an exception listed in retry_exceptions" do
+      ExternalService.call(@fuse_name, @retry_runtime_errors, fn ->
         Process.put(@fuse_name, Process.get(@fuse_name) + 1)
         raise "KABOOM!"
       end)
@@ -124,8 +124,8 @@ defmodule ExternalServiceTest do
       assert Process.get(@fuse_name) == @fuse_retries + 1
     end
 
-    test "calls function again when it raises another exception type listed in retry_on" do
-      retry_opts = %{@retry_opts | retry_on: [ArithmeticError, ArgumentError]}
+    test "calls function again when it raises another exception type listed in retry_exceptions" do
+      retry_opts = %{@retry_opts | retry_exceptions: [ArithmeticError, ArgumentError]}
 
       ExternalService.call(@fuse_name, retry_opts, fn ->
         Process.put(@fuse_name, Process.get(@fuse_name) + 1)
@@ -135,8 +135,8 @@ defmodule ExternalServiceTest do
       assert Process.get(@fuse_name) == @fuse_retries + 1
     end
 
-    test "does not call function again when it raises an exception not listed in retry_on" do
-      retry_opts = %{@retry_opts | retry_on: [SystemLimitError, File.Error]}
+    test "does not call function again when it raises an exception not listed in retry_exceptions" do
+      retry_opts = %{@retry_opts | retry_exceptions: [SystemLimitError, File.Error]}
 
       assert_raise(RuntimeError, fn ->
         ExternalService.call(@fuse_name, retry_opts, fn ->
@@ -148,8 +148,8 @@ defmodule ExternalServiceTest do
       assert Process.get(@fuse_name) == 1
     end
 
-    test "an exception not listed in retry_on does not melt the circuit breaker" do
-      retry_opts = %{@retry_opts | retry_on: [ArgumentError]}
+    test "an exception not listed in retry_exceptions does not melt the circuit breaker" do
+      retry_opts = %{@retry_opts | retry_exceptions: [ArgumentError]}
 
       # Raise far more times than the breaker would tolerate; because the
       # exception is not retriable, none of these should count as a failure.
@@ -173,7 +173,7 @@ defmodule ExternalServiceTest do
 
     test "returns CircuitBreakerOpen when the fuse is blown by exceptions" do
       res =
-        ExternalService.call(@fuse_name, @retry_on_runtime, fn ->
+        ExternalService.call(@fuse_name, @retry_runtime_errors, fn ->
           raise "KABOOM!"
         end)
 
@@ -213,6 +213,64 @@ defmodule ExternalServiceTest do
         end)
 
       assert res == {:error, "reason"}
+    end
+
+    test "calls function again when the retry_on predicate matches the result" do
+      retry_opts = %{@retry_opts | retry_on: &match?({:error, _}, &1)}
+
+      ExternalService.call(@fuse_name, retry_opts, fn ->
+        Process.put(@fuse_name, Process.get(@fuse_name) + 1)
+        {:error, :nope}
+      end)
+
+      assert Process.get(@fuse_name) == @fuse_retries + 1
+    end
+
+    test "returns the result unchanged when the retry_on predicate does not match" do
+      retry_opts = %{@retry_opts | retry_on: &match?({:error, _}, &1)}
+
+      res =
+        ExternalService.call(@fuse_name, retry_opts, fn ->
+          Process.put(@fuse_name, Process.get(@fuse_name) + 1)
+          {:ok, :good}
+        end)
+
+      assert res == {:ok, :good}
+      assert Process.get(@fuse_name) == 1
+    end
+
+    test "a result matched by the retry_on predicate melts the circuit breaker" do
+      retry_opts = %{@retry_opts | retry_on: &match?({:error, _}, &1)}
+
+      res = ExternalService.call(@fuse_name, retry_opts, fn -> {:error, :boom} end)
+
+      assert {:error, %CircuitBreakerOpen{context: %{service: @fuse_name}}} = res
+    end
+
+    test "exhausting retries via the retry_on predicate surfaces the result as the reason" do
+      retry_opts = %RetryOptions{
+        backoff: :linear,
+        base: 1,
+        expiry: 1,
+        retry_on: &match?({:error, _}, &1)
+      }
+
+      res = ExternalService.call(@fuse_name, retry_opts, fn -> {:error, :boom} end)
+
+      assert {:error, %RetriesExhausted{context: %{reason: {:error, :boom}}}} = res
+    end
+
+    test "an explicit :retry return takes precedence over the retry_on predicate" do
+      # The predicate never matches, yet an explicit `:retry` must still retry:
+      # the `:retry` protocol is handled before the predicate is ever consulted.
+      retry_opts = %{@retry_opts | retry_on: fn _ -> false end}
+
+      ExternalService.call(@fuse_name, retry_opts, fn ->
+        Process.put(@fuse_name, Process.get(@fuse_name) + 1)
+        :retry
+      end)
+
+      assert Process.get(@fuse_name) == @fuse_retries + 1
     end
 
     test "calls sleep function when rate limit is reached" do
@@ -349,9 +407,9 @@ defmodule ExternalServiceTest do
       assert Process.get(@fuse_name) == 2
     end
 
-    test "calls function again when it raises an exception listed in retry_on" do
+    test "calls function again when it raises an exception listed in retry_exceptions" do
       try do
-        ExternalService.call!(@fuse_name, @retry_on_runtime, fn ->
+        ExternalService.call!(@fuse_name, @retry_runtime_errors, fn ->
           Process.put(@fuse_name, Process.get(@fuse_name) + 1)
           raise "KABOOM!"
         end)
@@ -373,7 +431,7 @@ defmodule ExternalServiceTest do
 
     test "raises CircuitBreakerOpen when the fuse is blown by exceptions" do
       assert_raise CircuitBreakerOpen, fn ->
-        ExternalService.call!(@fuse_name, @retry_on_runtime, fn -> raise "KABOOM!" end)
+        ExternalService.call!(@fuse_name, @retry_runtime_errors, fn -> raise "KABOOM!" end)
       end
     end
 
@@ -684,9 +742,25 @@ defmodule ExternalServiceTest do
                        %{service: ^name, reason: :boom}}
     end
 
+    test "emits a retry event carrying the result when the retry_on predicate matches" do
+      name = start_fuse(:"telemetry-retry-on")
+
+      retry_opts = %RetryOptions{
+        backoff: :linear,
+        base: 1,
+        expiry: 1,
+        retry_on: &match?({:error, _}, &1)
+      }
+
+      ExternalService.call(name, retry_opts, fn -> {:error, :boom} end)
+
+      assert_received {:telemetry, [:external_service, :call, :retry], %{count: 1},
+                       %{service: ^name, reason: {:error, :boom}}}
+    end
+
     test "emits a call exception event when the function raises a non-retriable error" do
       name = start_fuse(:"telemetry-exception")
-      retry_opts = %RetryOptions{backoff: :linear, base: 0, retry_on: [ArgumentError]}
+      retry_opts = %RetryOptions{backoff: :linear, base: 0, retry_exceptions: [ArgumentError]}
 
       assert_raise RuntimeError, fn ->
         ExternalService.call(name, retry_opts, fn -> raise "boom" end)


### PR DESCRIPTION
## Summary

Adds a **result-based retry predicate** and renames the existing exception-list option to make room for it — both landing in the `2.0.0` cycle (intended for a `2.0.0-rc.2`).

- **New `retry_on` predicate** — an arity-1 function (`{:fun, 1}`) run on the call's return value. When it returns a truthy value, the call is retried exactly as if the function had returned `{:retry, result}`: the circuit breaker melts, `[:external_service, :call, :retry]` fires, and the result itself becomes the retry reason (so it flows into `RetriesExhausted` and telemetry metadata). Lets you drive retries from a function that was *not* written to return `:retry` — the common case when adapting an existing client. An explicit `:retry` / `{:retry, reason}` return always takes precedence. Defaults to no predicate, so existing behavior is unchanged.
- **Rename `retry_on` → `retry_exceptions`** (the exception-module list). This is an RC-internal rename relative to `2.0.0-rc.1`, where the option was brand new (it was `rescue_only` in 1.x). Doing it now means no stable release ever ships `retry_on` meaning "exception list", so there's no breakage and no deprecation cycle. The new `retry_on` is typed as a function, so a leftover `retry_on: [SomeError]` from rc.1 fails loudly with a `NimbleOptions.ValidationError` at `start/2`.

After this change, "what counts as a failure" is uniform: an explicit `:retry`/`{:retry, reason}` return, a result matched by the `:retry_on` predicate, or a raised exception listed in `:retry_exceptions` — all retry and melt the breaker.

```elixir
# Retry any 5xx from an unmodified client function:
retry: [retry_on: &match?({:error, %{status: s}} when s in 500..599, &1)]
call fn -> Stripe.charge(params) end
```

## Implementation

- `maybe_retry_on_result/3` in the `result ->` branch of `try_function/3` converts a predicate-matched result into the existing `{:error, {:retry, result}}` retry path.
- `RetryOptions` gains `retry_on` (`{:fun, 1}`, default `nil`) and renames `retry_on` → `retry_exceptions`.

## Docs

Moduledocs, all guides, the cheatsheet, the migration guide, and the CHANGELOG (`[Unreleased]`) updated. The rc.1 CHANGELOG entry is left intact; the rc.1→rc.2 rename and the new predicate are recorded under `[Unreleased]`.

## Tests

6 new tests: predicate triggers retries; result passes through on no-match; predicate-driven retry melts the breaker; exhaustion carries the result as the reason; explicit `:retry` precedence; telemetry reason = the result.

- `mix test` → 87 passing
- `mix format --check-formatted`, `mix docs --warnings-as-errors`, `mix dialyzer` → all clean

## Notes for the reviewer

- **No version bump / tag / publish here** — changes sit under `[Unreleased]`. Cutting `2.0.0-rc.2` (bump `@version`, stamp the CHANGELOG date, tag, `mix hex.publish`) is left as a separate release step.
- The second commit checks in `CLAUDE.md` (previously untracked) as shared project guidance — independent of the feature; easy to drop if you'd rather it not be in this PR.

Closes #29. Unblocks the cleaner adapter story for #28 (the decorator inherits `retry_on` through its `retry:` overrides).
