### PR TITLE
Add ExternalService.Decorator (@decorate external_call) [2.1.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `ExternalService.Decorator`: decorator-based annotations for marking a function
+  as an external call ([issue #28](https://github.com/jvoegele/external_service/issues/28)).
+  `use ExternalService.Decorator` brings `@decorate external_call(service)` (and a
+  raising `external_call!`) into scope, wrapping the function body in
+  `ExternalService.call/2` (or `call/3` when passed per-call retry options) instead
+  of writing `call fn -> ... end` by hand. Built on the
+  [`decorator`](https://hex.pm/packages/decorator) library.
+
 ## [2.0.0] - 2026-06-23
 
 The 2.0 line modernizes the project and introduces breaking changes. See the

--- a/guides/the-front-door.md
+++ b/guides/the-front-door.md
@@ -143,6 +143,58 @@ ExternalService.call({:tenant, tenant_id}, fn -> fetch(tenant_id) end)
 The two styles interoperate freely; the front door is just the ergonomic
 default.
 
+## Decorator annotations
+
+If you'd rather not wrap each body in `call fn -> ... end`, `ExternalService.Decorator`
+lets you mark a function as an external call with a `@decorate` annotation and write
+the body directly. It's a thin convenience layer over `call` — nothing more.
+
+```elixir
+defmodule MyApp.Payments do
+  use ExternalService.Decorator
+
+  @decorate external_call(MyApp.Stripe)
+  def charge(params) do
+    case Stripe.charge(params) do
+      {:error, %{status: s}} when s in 500..599 -> :retry
+      other -> other
+    end
+  end
+
+  @decorate external_call!(MyApp.Stripe)
+  def capture(id), do: Stripe.capture(id)
+end
+```
+
+The decorated body *is* the retriable function, so the same retry protocol applies:
+it drives retries by returning `:retry` / `{:retry, reason}`, and the call returns the
+body's value on success or a structured error on failure. `external_call!` raises
+instead of returning, mirroring `call!`.
+
+The service argument is any started service term — it need not be the module the
+function lives in, so one module can front several services.
+
+To retry based on the **return value** of an unmodified function, pass per-call retry
+options (the same ones `call/3` accepts) as a second argument — most usefully a
+`:retry_on` predicate:
+
+```elixir
+@decorate external_call(MyApp.Stripe, retry_on: &match?({:error, %{status: 500}}, &1))
+def charge(params), do: Stripe.charge(params)
+```
+
+> #### Multi-clause functions, default args, and guards {: .info}
+>
+> Annotate an empty function head and let it cover every clause:
+>
+> ```elixir
+> @decorate external_call(MyApp.Stripe)
+> def fetch(id, opts \\ [])
+> def fetch(id, opts) when is_integer(id), do: Client.get(id, opts)
+> ```
+
+See `ExternalService.Decorator` for the full reference.
+
 ## Migrating from `ExternalService.Gateway`
 
 `use ExternalService.Gateway` (the 1.x module-based gateway) still works but is

--- a/lib/external_service/decorator.ex
+++ b/lib/external_service/decorator.ex
@@ -1,0 +1,100 @@
+defmodule ExternalService.Decorator do
+  @moduledoc """
+  Decorator-based annotations for marking functions as external-service calls.
+
+  This is a thin convenience layer over the [module front door](`ExternalService`):
+  instead of wrapping a function body in `call fn -> ... end` by hand, you annotate
+  the function with `@decorate external_call(service)` and write the body directly.
+
+  `use ExternalService.Decorator` brings the decorators into scope (built on the
+  [`decorator`](https://hex.pm/packages/decorator) library):
+
+      defmodule MyApp.Payments do
+        use ExternalService.Decorator
+
+        @decorate external_call(MyApp.Stripe)
+        def charge(params) do
+          case Stripe.charge(params) do
+            {:error, %{status: s}} when s in 500..599 -> :retry
+            other -> other
+          end
+        end
+      end
+
+  The annotated function behaves exactly as if its body were passed to
+  `ExternalService.call/2`: it returns the body's value on success, or a structured
+  error (`ExternalService.RetriesExhausted` / `ExternalService.CircuitBreakerOpen` /
+  `ExternalService.ServiceNotStarted`) on failure.
+
+  The `service` argument is any term identifying a service that has been started
+  (via `ExternalService.start/2` or `use ExternalService`). It need not be the
+  module the decorated function lives in, so a single module can decorate calls to
+  several services.
+
+  ## The retry protocol still applies
+
+  The decorated body *is* the retriable function, so it drives retries the same way
+  the body of `call fn -> ... end` would — by returning `:retry` / `{:retry, reason}`,
+  or by configuring a retry option. A body that just returns the underlying client's
+  result is **not** retried unless you tell it how. Two ways to do that:
+
+    * return `:retry` / `{:retry, reason}` from the body (as above), or
+    * pass per-call retry options as the second decorator argument, for example a
+      `:retry_on` predicate that decides from the return value — handy when the body
+      is an unmodified client call:
+
+          @decorate external_call(MyApp.Stripe, retry_on: &match?({:error, %{status: 500}}, &1))
+          def charge(params), do: Stripe.charge(params)
+
+  The second argument is the same per-call retry options accepted by
+  `ExternalService.call/3` (a keyword list of overrides merged onto the service's
+  defaults, or a `t:ExternalService.RetryOptions.t/0` struct).
+
+  ## Raising variant
+
+  `external_call!` mirrors `ExternalService.call!/2,3`: it raises the structured
+  error instead of returning it.
+
+      @decorate external_call!(MyApp.Stripe)
+      def capture(id), do: Stripe.capture(id)
+
+  ## Decorators
+
+    * `external_call(service)` / `external_call(service, retry_opts)`
+    * `external_call!(service)` / `external_call!(service, retry_opts)`
+  """
+
+  use Decorator.Define,
+    external_call: 1,
+    external_call: 2,
+    external_call!: 1,
+    external_call!: 2
+
+  @doc "Wraps the function body in `ExternalService.call/2`."
+  def external_call(service, body, _context) do
+    quote do
+      ExternalService.call(unquote(service), fn -> unquote(body) end)
+    end
+  end
+
+  @doc "Wraps the function body in `ExternalService.call/3` with per-call retry options."
+  def external_call(service, retry_opts, body, _context) do
+    quote do
+      ExternalService.call(unquote(service), unquote(retry_opts), fn -> unquote(body) end)
+    end
+  end
+
+  @doc "Wraps the function body in `ExternalService.call!/2`."
+  def external_call!(service, body, _context) do
+    quote do
+      ExternalService.call!(unquote(service), fn -> unquote(body) end)
+    end
+  end
+
+  @doc "Wraps the function body in `ExternalService.call!/3` with per-call retry options."
+  def external_call!(service, retry_opts, body, _context) do
+    quote do
+      ExternalService.call!(unquote(service), unquote(retry_opts), fn -> unquote(body) end)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule ExternalService.Mixfile do
       {:retry, "~> 0.18"},
       {:ex_rated, "~> 2.1"},
       {:deep_merge, "~> 1.0"},
+      {:decorator, "~> 1.4"},
       {:errata, "~> 1.3"},
       {:nimble_options, "~> 1.1"},
       {:telemetry, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "credo": {:hex, :credo, "1.7.19", "cc52129665fc7c15143d47838fda0f9cd6dac9ceced7bf4da6f85fcbfe64b12a", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "2d8bc95d5a7bb99dd2613621d4f08c6a3575c3fd4b62e6a2b48a100352a557b8"},
+  "decorator": {:hex, :decorator, "1.4.0", "a57ac32c823ea7e4e67f5af56412d12b33274661bb7640ec7fc882f8d23ac419", [:mix], [], "hexpm", "0a07cedd9083da875c7418dea95b78361197cf2bf3211d743f6f7ce39656597f"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.4.7", "dda948fcee52962e4b6c5b4b16b2d8fa7d50d8645bbae8b8685c3f9ecb7f5f4d", [:mix], [{:erlex, ">= 0.2.8", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b34527202e6eb8cee198efec110996c25c5898f43a4094df157f8d28f27d9efe"},
   "earmark": {:hex, :earmark, "1.4.4", "4821b8d05cda507189d51f2caeef370cf1e18ca5d7dfb7d31e9cafe6688106a4", [:mix], [], "hexpm", "1f93aba7340574847c0f609da787f0d79efcab51b044bb6e242cae5aca9d264d"},

--- a/test/external_service/decorator_test.exs
+++ b/test/external_service/decorator_test.exs
@@ -1,0 +1,126 @@
+defmodule ExternalService.DecoratorTest do
+  use ExUnit.Case
+
+  alias ExternalService.RetriesExhausted
+
+  @moduletag capture_log: true
+
+  @service :decorator_test_service
+
+  # A module that exercises the decorators across the shapes of `def` that the
+  # underlying `decorator` library is historically fussy about: single clause,
+  # multiple clauses, default arguments, and guards (the last three using the
+  # documented empty-function-head pattern).
+  defmodule Client do
+    use ExternalService.Decorator
+
+    @service :decorator_test_service
+
+    # Single clause, plain value result.
+    @decorate external_call(@service)
+    def ok(x), do: {:ok, x}
+
+    # Body drives a retry via the `:retry` protocol.
+    @decorate external_call(@service)
+    def flaky do
+      count = Process.get(:flaky, 0) + 1
+      Process.put(:flaky, count)
+      if count < 3, do: :retry, else: {:ok, count}
+    end
+
+    # Soft failure: returns the structured error.
+    @decorate external_call(@service)
+    def always_retry, do: :retry
+
+    # Multiple clauses (decorate the function head).
+    @decorate external_call(@service)
+    def classify(value)
+    def classify(:a), do: {:ok, :a}
+    def classify(:b), do: {:ok, :b}
+
+    # Default argument (decorate the function head).
+    @decorate external_call(@service)
+    def greet(name, greeting \\ "hi")
+    def greet(name, greeting), do: {:ok, "#{greeting} #{name}"}
+
+    # Guard.
+    @decorate external_call(@service)
+    def positive(n) when n > 0, do: {:ok, n}
+
+    # Per-call retry options: a `:retry_on` predicate retries an unmodified body
+    # that returns the underlying client's own result shape.
+    @decorate external_call(@service, retry_on: &match?({:error, _}, &1))
+    def adapted do
+      count = Process.get(:adapted, 0) + 1
+      Process.put(:adapted, count)
+      if count < 3, do: {:error, :nope}, else: {:ok, count}
+    end
+
+    # Raising variant: returns on success...
+    @decorate external_call!(@service)
+    def bang(x), do: {:ok, x}
+
+    # ...and raises the structured error on failure.
+    @decorate external_call!(@service)
+    def bang_retry, do: :retry
+  end
+
+  setup do
+    Process.delete(:flaky)
+    Process.delete(:adapted)
+
+    ExternalService.start(@service,
+      circuit_breaker: [tolerate: 100, within: 10_000],
+      retry: [backoff: :linear, base: 0, max_attempts: 3]
+    )
+
+    on_exit(fn -> ExternalService.stop(@service) end)
+    :ok
+  end
+
+  describe "external_call/1" do
+    test "wraps a single-clause body and returns its value" do
+      assert Client.ok(:payload) == {:ok, :payload}
+    end
+
+    test "a :retry return from the body drives a retry" do
+      assert Client.flaky() == {:ok, 3}
+      assert Process.get(:flaky) == 3
+    end
+
+    test "returns a structured error when retries are exhausted" do
+      assert {:error, %RetriesExhausted{context: %{service: @service}}} = Client.always_retry()
+    end
+
+    test "works across multiple clauses via the function head" do
+      assert Client.classify(:a) == {:ok, :a}
+      assert Client.classify(:b) == {:ok, :b}
+    end
+
+    test "works with a default argument via the function head" do
+      assert Client.greet("Bob") == {:ok, "hi Bob"}
+      assert Client.greet("Bob", "yo") == {:ok, "yo Bob"}
+    end
+
+    test "works with a guard" do
+      assert Client.positive(5) == {:ok, 5}
+    end
+  end
+
+  describe "external_call/2 with per-call retry options" do
+    test "a :retry_on predicate retries an unmodified body" do
+      assert Client.adapted() == {:ok, 3}
+      assert Process.get(:adapted) == 3
+    end
+  end
+
+  describe "external_call!" do
+    test "returns the body's value on success" do
+      assert Client.bang(:payload) == {:ok, :payload}
+    end
+
+    test "raises the structured error on failure" do
+      assert_raise RetriesExhausted, fn -> Client.bang_retry() end
+    end
+  end
+end


### PR DESCRIPTION
> **Draft — targets 2.1.0, do not merge into the 2.0.0 cut.** This is additive convenience work kept deliberately off `master` until `2.0.0` final is tagged (see #25). Opening as a draft for review in the meantime.

## Summary

Implements #28: decorator-based annotations for marking a function as an external-service call, as a thin convenience layer over the module front door.

```elixir
defmodule MyApp.Payments do
  use ExternalService.Decorator

  @decorate external_call(MyApp.Stripe)
  def charge(params) do
    case Stripe.charge(params) do
      {:error, %{status: s}} when s in 500..599 -> :retry
      other -> other
    end
  end

  @decorate external_call!(MyApp.Stripe)
  def capture(id), do: Stripe.capture(id)
end
```

- `use ExternalService.Decorator` brings `@decorate external_call(service)` / `external_call!(service)` into scope (built on the [`decorator`](https://hex.pm/packages/decorator) library).
- The decorated body **is** the retriable function: it drives retries by returning `:retry` / `{:retry, reason}`, returns the body's value on success, and a structured error (`RetriesExhausted` / `CircuitBreakerOpen` / `ServiceNotStarted`) on failure. `external_call!` raises instead, mirroring `call!`.
- The optional second argument is the **same per-call retry options `call/3` accepts** (a bare keyword list of overrides or a `RetryOptions` struct) — most usefully a `:retry_on` predicate to retry an unmodified body based on its return value:
  ```elixir
  @decorate external_call(MyApp.Stripe, retry_on: &match?({:error, %{status: 500}}, &1))
  def charge(params), do: Stripe.charge(params)
  ```
- The `service` term need not be the module the function lives in, so one module can front several services.

## Note on the option shape

The spec on #28 sketched the override as `external_call(Svc, retry: [...])`. That `retry:` wrapper was inconsistent with `call/3`, whose second argument is the bare retry-options list. This PR implements the honest mapping (`external_call(Svc, retry_on: &…)`, no wrapper); I've posted a correction on #28.

## Tests

`test/external_service/decorator_test.exs` — 9 tests covering the decorator sharp edges and behavior: single clause, multiple clauses, default args, and guards (the last three via the documented empty-function-head pattern); the returning and raising variants; structured-error return on exhaustion; and a `:retry_on` predicate retrying an unmodified body.

- `mix test` → 96 passing
- `mix format --check-formatted`, `mix docs --warnings-as-errors`, `mix dialyzer` → all clean

## Dependency

Adds `{:decorator, "~> 1.4"}` (pinned 1.4.0). This new runtime dep + new public API is exactly why it's 2.1.0 and not folded into the 2.0.0 RC — it deserves its own soak rather than entering the final un-soaked.

Closes #28.
